### PR TITLE
feat(forgejo): fix DB persistence, SSH via gateway, add Actions runner

### DIFF
--- a/kubernetes/apps/misc/forgejo/app/dnsendpoint.yaml
+++ b/kubernetes/apps/misc/forgejo/app/dnsendpoint.yaml
@@ -7,7 +7,7 @@ spec:
   endpoints:
     - dnsName: "ssh.git.nikola.wtf"
       recordType: A
-      targets: ["10.40.0.40"]
+      targets: ["10.40.0.50"]
       providerSpecific:
         - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
           value: "false"

--- a/kubernetes/apps/misc/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/misc/forgejo/app/helmrelease.yaml
@@ -34,10 +34,8 @@ spec:
       http:
         port: 3000
       ssh:
-        type: LoadBalancer
-        port: 2222
-        loadBalancerIP: 10.40.0.40
-        externalTrafficPolicy: Local
+        type: ClusterIP
+        port: 22
 
     resources:
       requests:
@@ -65,18 +63,19 @@ spec:
           ROOT_URL: https://git.nikola.wtf
           DISABLE_SSH: false
           SSH_DOMAIN: ssh.git.nikola.wtf
-          SSH_PORT: 2222
-          SSH_LISTEN_PORT: 2222
+          SSH_PORT: 22 # advertised in clone URLs; reached via the external gateway ssh listener
+          SSH_LISTEN_PORT: 2222 # container binds 2222 (non-privileged); service maps 22 -> 2222
           ENABLE_GZIP: true
           LFS_START_SERVER: true
           OFFLINE_MODE: false # Enable CDN for static files and Gravatar
           LANDING_PAGE: explore # Show explore page for non-authenticated users
         database:
           DB_TYPE: sqlite3
+          PATH: /data/forgejo.db # absolute path on the config PVC; otherwise sqlite resolves relative to the ephemeral GITEA_WORK_DIR (/var/lib/gitea) and is lost on every pod restart
         indexer:
           REPO_INDEXER_ENABLED: true
           REPO_INDEXER_REPO_TYPES: sources,forks,mirrors,templates
-          ISSUE_INDEXER_TYPE: db # Use database for issue indexing (simpler than bleve)
+          ISSUE_INDEXER_TYPE: bleve # bleve index persists under /data/indexers
         queue:
           TYPE: redis
           CONN_STR: redis://redis-forgejo.database.svc.cluster.local:6379
@@ -174,7 +173,7 @@ spec:
           LOG_RETENTION_DAYS: 365
           LOG_COMPRESSION: zstd # Compress action logs
       additionalConfigFromEnvs:
-        # Database - CNPG auto-generated connection string
+        # SECRET_KEY sourced from 1Password via External Secrets (forgejo-secret)
         - name: GITEA__SECURITY__SECRET_KEY
           valueFrom:
             secretKeyRef:
@@ -183,6 +182,12 @@ spec:
       podAnnotations:
         reloader.stakater.com/search: "true"
 
+    tcpRoute:
+      enabled: true
+      parentRefs:
+        - name: external
+          namespace: network
+          sectionName: ssh
     ingress:
       enabled: false
     valkey-cluster:

--- a/kubernetes/apps/misc/forgejo/ks.yaml
+++ b/kubernetes/apps/misc/forgejo/ks.yaml
@@ -33,3 +33,29 @@ spec:
       APP: *app
       VOLSYNC_CLAIM: forgejo
       VOLSYNC_CAPACITY: 10Gi
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app forgejo-runner
+spec:
+  targetNamespace: misc
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: forgejo
+      namespace: misc
+    - name: external-secrets-stores
+      namespace: security
+  path: ./kubernetes/apps/misc/forgejo/runner
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/misc/forgejo/runner/externalsecret.yaml
+++ b/kubernetes/apps/misc/forgejo/runner/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: forgejo-runner
+  namespace: misc
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: onepassword-connect
+    kind: ClusterSecretStore
+  target:
+    name: forgejo-runner-secret
+    template:
+      engineVersion: v2
+      data:
+        token: "{{ .token }}"
+        uuid: "{{ .uuid }}"
+  dataFrom:
+    - extract:
+        key: forgejo-runner

--- a/kubernetes/apps/misc/forgejo/runner/helmrelease.yaml
+++ b/kubernetes/apps/misc/forgejo/runner/helmrelease.yaml
@@ -1,0 +1,137 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: forgejo-runner
+  namespace: misc
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: forgejo-runner
+  values:
+    forgejo:
+      url: http://forgejo-http.misc.svc.cluster.local:3000
+      existingSecret: forgejo-runner-secret
+    image:
+      repository: git.erwanleboucher.dev/eleboucher/runner
+      tag: 12.13.0
+    plugin:
+      image:
+        repository: git.erwanleboucher.dev/eleboucher/runner-k8s-plugin
+    podLabels:
+      app.kubernetes.io/component: forgejo-runner
+    # Full runner.yaml. Jobs execute as their own pods via the k8s plugin (unix socket
+    # at plugin.socketPath); options.namespace must be the namespace this release runs in.
+    runnerConfig: |
+      cache:
+        enabled: true
+        dir: /data/cache
+        port: 8088
+        proxy_port: 8089
+      container:
+        docker_host: "-"
+        workdir_parent: shared/workdir
+      host:
+        workdir_parent: /data/act
+      log:
+        level: info
+      plugins:
+        k8s:
+          address: "unix:///plugin/forgejo-runner-k8s.sock"
+          options:
+            namespace: misc
+            poll_timeout: 10m
+            labels: "app.kubernetes.io/name=forgejo-runner-instance"
+            resources: |
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+      runner:
+        capacity: 2
+        labels:
+          - ubuntu-latest:k8s:/config/podspec-default.yaml
+          - ubuntu-24.04:k8s:/config/podspec-default.yaml
+          - default:k8s:/config/podspec-default.yaml
+          - docker:k8s:/config/podspec-dind.yaml
+        timeout: 3h
+        shutdown_timeout: 3m
+    # PodSpec templates referenced by the runner labels above.
+    podSpecs:
+      podspec-default.yaml: |-
+        containers:
+          - name: main
+            image: ghcr.io/catthehacker/ubuntu:act-24.04
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: DEBIAN_FRONTEND
+                value: noninteractive
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 4Gi
+        restartPolicy: Never
+      podspec-dind.yaml: |-
+        initContainers:
+          - name: dind
+            image: docker:29-dind
+            securityContext:
+              privileged: true
+            restartPolicy: Always
+            env:
+              - name: DOCKER_TLS_CERTDIR
+                value: /certs
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 4Gi
+            volumeMounts:
+              - name: docker-storage
+                mountPath: /var/lib/docker
+              - name: docker-certs
+                mountPath: /certs
+            startupProbe:
+              exec:
+                command:
+                  - sh
+                  - -c
+                  - docker --tlsverify --tlscacert=/certs/client/ca.pem --tlscert=/certs/client/cert.pem --tlskey=/certs/client/key.pem -H tcp://localhost:2376 info
+              initialDelaySeconds: 5
+              periodSeconds: 1
+              failureThreshold: 30
+        containers:
+          - name: main
+            image: ghcr.io/catthehacker/ubuntu:act-24.04
+            imagePullPolicy: IfNotPresent
+            env:
+              - name: DEBIAN_FRONTEND
+                value: noninteractive
+              - name: DOCKER_HOST
+                value: tcp://localhost:2376
+              - name: DOCKER_TLS_VERIFY
+                value: "1"
+              - name: DOCKER_CERT_PATH
+                value: /certs/client
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 4Gi
+            volumeMounts:
+              - name: docker-certs
+                mountPath: /certs
+                readOnly: true
+        volumes:
+          - name: docker-storage
+            emptyDir: {}
+          - name: docker-certs
+            emptyDir: {}
+        restartPolicy: Never

--- a/kubernetes/apps/misc/forgejo/runner/kustomization.yaml
+++ b/kubernetes/apps/misc/forgejo/runner/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: misc
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/misc/forgejo/runner/ocirepository.yaml
+++ b/kubernetes/apps/misc/forgejo/runner/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: forgejo-runner
+  namespace: misc
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 12.10.9
+  url: oci://git.erwanleboucher.dev/eleboucher/charts/forgejo-runner

--- a/kubernetes/apps/network/envoy-gateway/config/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/config/envoy.yaml
@@ -113,6 +113,14 @@ spec:
         certificateRefs:
           - kind: Secret
             name: nikola-wtf-tls
+    - name: ssh
+      protocol: TCP
+      port: 22
+      allowedRoutes:
+        kinds:
+          - kind: TCPRoute
+        namespaces:
+          from: All
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/refs/heads/main/gateway.envoyproxy.io/backendtrafficpolicy_v1alpha1.json
 apiVersion: gateway.envoyproxy.io/v1alpha1


### PR DESCRIPTION
## Summary

Three related Forgejo changes:

### 1. Fix SQLite persistence (the "recreate admin on every upgrade" bug)
The sqlite DB defaulted to a relative path resolved against the **ephemeral** `GITEA_WORK_DIR` (`/var/lib/gitea`), so users/issues/PRs/settings were wiped on every pod restart while bare git repos (on the `/data` PVC) survived. Pinned `database.PATH: /data/forgejo.db` (on the Ceph PVC).

### 2. SSH via the external gateway + misc cleanup
- SSH: `LoadBalancer 10.40.0.40:2222` → `ClusterIP` + chart-native `tcpRoute` on the **external** Envoy gateway (new `ssh` TCP listener, port 22). `SSH_PORT: 22`, `SSH_LISTEN_PORT: 2222`.
- `ssh.git.nikola.wtf` A record → `10.40.0.50`.
- `ISSUE_INDEXER_TYPE: db` → `bleve`.
- Dropped a stale CNPG comment.

> Note: the `external` gateway is internet-exposed only via the HTTP(S) Cloudflare Tunnel, which cannot carry raw SSH. This makes SSH reachable at `10.40.0.50:22` on the LAN; true internet SSH needs a WAN port-forward (TCP/22 → 10.40.0.50) + public DNS.

### 3. Kubernetes-backend Actions runner
New `forgejo/runner/` sub-app (Erwan Le Boucher chart, runner `12.13.0` / chart+plugin `12.10.9`). CI jobs run as **individual pods** via the k8s plugin. Labels: `ubuntu-latest`/`ubuntu-24.04`/`default` → `catthehacker/ubuntu:act-24.04`; `docker` → DinD pod. Registration `token`+`uuid` from a 1Password item (`forgejo-runner`) via External Secrets.

## Deploy prerequisites (before merge)
1. Copy the live DB onto the PVC (one-time migration).
2. Create the `forgejo-runner` 1Password item in the `homecluster` vault.

## Validation
- `helm template` renders app + runner correctly
- `kustomize build` passes for forgejo/app, forgejo/runner, envoy config
- yamllint clean; privileged DinD allowed in `misc` (server dry-run)