### PR TITLE
fix(atuin-ai): accept 4xx in gatus healthcheck

### DIFF
--- a/kubernetes/apps/ai/atuin-ai/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/atuin-ai/app/helmrelease.yaml
@@ -57,6 +57,11 @@ spec:
             port: &port 8080
     route:
       app:
+        annotations:
+          # atuin-ai has no root route; / returns 4xx. Treat any non-5xx as up.
+          gatus.home-operations.com/endpoint: |
+            conditions:
+              - "[STATUS] < 500"
         hostnames:
           - atuin-ai.nikola.wtf
         parentRefs:


### PR DESCRIPTION
atuin-ai has no root route; `/` returns 4xx, which the gatus auto-discovery sidecar's default `[STATUS] == 200` check flagged as down.

This overrides the endpoint condition on the HTTPRoute to `[STATUS] < 500` so any non-5xx response counts as up (same pattern used for memini and hermes).

```yaml
route:
  app:
    annotations:
      gatus.home-operations.com/endpoint: |
        conditions:
          - "[STATUS] < 500"
```