### PR TITLE
fix(esphome): increase config PVC 5Gi -> 10Gi

### DIFF
--- a/kubernetes/apps/home/esphome/ks.yaml
+++ b/kubernetes/apps/home/esphome/ks.yaml
@@ -34,4 +34,4 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CLAIM: esphome-config
-      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_CAPACITY: 10Gi


### PR DESCRIPTION
The esphome config PVC is at ~0.9% free (KubePersistentVolumeFillingUp firing). ESPHome 2026.7.0's self-managed ESP-IDF toolchain installed into /config/.cache and repeated failed installs filled the volume. Bump VOLSYNC_CAPACITY to 10Gi (ceph-block supports online expansion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)