### PR TITLE
feat(cobalt): add cobalt media downloader API

### DIFF
--- a/kubernetes/apps/media/cobalt-web/app/helmrelease.yaml
+++ b/kubernetes/apps/media/cobalt-web/app/helmrelease.yaml
@@ -3,34 +3,30 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: cobalt
+  name: cobalt-web
   namespace: media
 spec:
   interval: 5m
   chartRef:
     kind: OCIRepository
-    name: cobalt
+    name: cobalt-web
   values:
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        runAsUser: 101
+        runAsGroup: 101
+        fsGroup: 101
         fsGroupChangePolicy: OnRootMismatch
     controllers:
-      cobalt:
+      cobalt-web:
         containers:
           app:
             image:
-              repository: ghcr.io/imputnet/cobalt
+              repository: quay.io/nklmilojevic/cobalt-web
               tag: 11.7.1
             env:
               TZ: "Europe/Belgrade"
-              API_URL: "https://cobalt-api.nikola.wtf/"
-              API_PORT: &port 9000
-              CORS_WILDCARD: "0"
-              CORS_URL: "https://cobalt.nikola.wtf"
             probes:
               liveness:
                 enabled: true
@@ -38,7 +34,7 @@ spec:
                 spec:
                   httpGet:
                     path: /
-                    port: *port
+                    port: &port 8080
                   initialDelaySeconds: 0
                   periodSeconds: 10
                   timeoutSeconds: 1
@@ -57,9 +53,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
-                memory: 128Mi
+                memory: 32Mi
               limits:
-                memory: 1Gi
+                memory: 128Mi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
@@ -68,14 +64,14 @@ spec:
                   - ALL
     service:
       app:
-        controller: cobalt
+        controller: cobalt-web
         ports:
           http:
             port: *port
     route:
       app:
         hostnames:
-          - cobalt-api.nikola.wtf
+          - cobalt.nikola.wtf
         parentRefs:
           - name: internal
             namespace: network

--- a/kubernetes/apps/media/cobalt-web/app/kustomization.yaml
+++ b/kubernetes/apps/media/cobalt-web/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: media
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/media/cobalt-web/app/ocirepository.yaml
+++ b/kubernetes/apps/media/cobalt-web/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cobalt-web
+  namespace: media
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/media/cobalt-web/ks.yaml
+++ b/kubernetes/apps/media/cobalt-web/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cobalt-web
+spec:
+  targetNamespace: media
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/media/cobalt-web/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app

--- a/kubernetes/apps/media/cobalt/app/helmrelease.yaml
+++ b/kubernetes/apps/media/cobalt/app/helmrelease.yaml
@@ -1,0 +1,89 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cobalt
+  namespace: media
+spec:
+  interval: 5m
+  chartRef:
+    kind: OCIRepository
+    name: cobalt
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      cobalt:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/imputnet/cobalt
+              tag: 11.7.1
+            env:
+              TZ: "Europe/Belgrade"
+              API_URL: "https://cobalt.nikola.wtf/"
+              API_PORT: &port 9000
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 1Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+    service:
+      app:
+        controller: cobalt
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.nikola.wtf"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: http
+    persistence:
+      tmpfs:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/media/cobalt/app/kustomization.yaml
+++ b/kubernetes/apps/media/cobalt/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: media
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/media/cobalt/app/ocirepository.yaml
+++ b/kubernetes/apps/media/cobalt/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cobalt
+  namespace: media
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/media/cobalt/ks.yaml
+++ b/kubernetes/apps/media/cobalt/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cobalt
+spec:
+  targetNamespace: media
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/media/cobalt/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./namespace.yaml
   - ./chaski/ks.yaml
   - ./cobalt/ks.yaml
+  - ./cobalt-web/ks.yaml
   - ./sonarr/ks.yaml
   - ./radarr/ks.yaml
   - ./bazarr/ks.yaml

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: media
 resources:
   - ./namespace.yaml
   - ./chaski/ks.yaml
+  - ./cobalt/ks.yaml
   - ./sonarr/ks.yaml
   - ./radarr/ks.yaml
   - ./bazarr/ks.yaml


### PR DESCRIPTION
## Summary

Adds [cobalt](https://github.com/imputnet/cobalt) (media downloader) to the `media` namespace — both the processing API and a self-hosted web UI.

### cobalt (API) — `https://cobalt-api.nikola.wtf`
- `ghcr.io/imputnet/cobalt:11.7.1` via bjw-s app-template 5.0.1
- Stateless — no volsync component / PVC (only an emptyDir `/tmp`, read-only rootfs like the upstream compose example)
- Runs as UID 1000 (`node` user in the image), all caps dropped
- CORS locked to the web UI origin (`CORS_WILDCARD=0`, `CORS_URL=https://cobalt.nikola.wtf`)

### cobalt-web (UI) — `https://cobalt.nikola.wtf`
- `quay.io/nklmilojevic/cobalt-web:11.7.1` — custom image from nklmilojevic/containers#396 (upstream ships no web image); static SvelteKit build with the API URL baked in, served by nginx-unprivileged (UID 101)
- Read-only rootfs, emptyDir `/tmp` for nginx temp files

> [!NOTE]
> Merge nklmilojevic/containers#396 first — the web UI image doesn't exist on quay until its release workflow runs.