### PR TITLE
chore(renovate): group bootstrap helmfile and flux chart bumps

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -8,7 +8,7 @@
       matchDatasources: ["docker", "helm"],
       group: {
         commitMessageTopic: "{{{groupName}}} group",
-        commitMessageSuffix: ""
+        commitMessageSuffix: "",
       },
     },
     {
@@ -17,12 +17,23 @@
       matchPackageNames: [
         "quay.io/cilium/cilium",
         "quay.io/cilium/operator-generic",
+        "quay.io/cilium/charts/cilium",
         "cilium",
       ],
       matchDatasources: ["helm", "docker"],
       group: {
         commitMessageTopic: "{{{groupName}}} group",
-        commitMessageSuffix: ""
+        commitMessageSuffix: "",
+      },
+    },
+    {
+      description: "CoreDNS bootstrap and Flux charts",
+      groupName: "coredns",
+      matchPackageNames: ["coredns", "ghcr.io/coredns/charts/coredns"],
+      matchDatasources: ["helm", "docker"],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+        commitMessageSuffix: "",
       },
     },
     {
@@ -35,21 +46,18 @@
       matchDatasources: ["helm", "docker"],
       group: {
         commitMessageTopic: "{{{groupName}}} group",
-        commitMessageSuffix: ""
+        commitMessageSuffix: "",
       },
       separateMinorPatch: false,
     },
     {
       description: "Talos",
       groupName: "Talos",
-      matchPackageNames: [
-        "ghcr.io/siderolabs/installer",
-        "ghcr.io/siderolabs/talosctl",
-      ],
+      matchPackageNames: ["ghcr.io/siderolabs/installer", "ghcr.io/siderolabs/talosctl"],
       matchDatasources: ["docker"],
       group: {
         commitMessageTopic: "{{{groupName}}} group",
-        commitMessageSuffix: ""
+        commitMessageSuffix: "",
       },
     },
     {
@@ -59,17 +67,17 @@
       matchDatasources: ["docker", "github-releases"],
       group: {
         commitMessageTopic: "{{{groupName}}} group",
-        commitMessageSuffix: ""
+        commitMessageSuffix: "",
       },
     },
     {
       description: ["Flux Operator Group"],
       groupName: "Flux Operator",
       matchPackagePatterns: ["flux-operator", "flux-instance"],
-      matchDatasources: ["docker"],
+      matchDatasources: ["docker", "github-releases"],
       group: {
         commitMessageTopic: "{{{groupName}}} group",
-        commitMessageSuffix: ""
+        commitMessageSuffix: "",
       },
     },
   ],


### PR DESCRIPTION
Cilium, CoreDNS, and Flux Operator are each pinned in two places — `bootstrap/helmfile.yaml` and their Flux `OCIRepository` — and Renovate was splitting each version bump into two PRs (e.g. #3906/#3907 for cilium 1.20.0, #3904/#3905 for coredns 1.47.0). Merging only the helmfile one silently skips the actual cluster upgrade.

- **cilium**: add `quay.io/cilium/charts/cilium` (Flux OCI chart) to the existing group
- **coredns**: new group covering the `coredns` helm package and `ghcr.io/coredns/charts/coredns`
- **Flux Operator**: add `github-releases` datasource so the helmfile's `# renovate:` pinned versions join the group

Spegel and prometheus-operator-crds already use the same OCI package name in both files, so they were never split.