### PR TITLE
feat(monitoring): sleep history from Apple Health

### DIFF
--- a/kubernetes/apps/monitoring/grafana-operator/instance/dashboards/kustomization.yaml
+++ b/kubernetes/apps/monitoring/grafana-operator/instance/dashboards/kustomization.yaml
@@ -7,5 +7,14 @@ resources:
   - ./kubernetes.yaml
   - ./monitoring.yaml
   - ./network.yaml
+  - ./sleep.yaml
   - ./unifi.yaml
   - ./victoriametrics.yaml
+configMapGenerator:
+  - name: sleep-dashboard
+    files:
+      - sleep-dashboard.json
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/monitoring/grafana-operator/instance/dashboards/sleep-dashboard.json
+++ b/kubernetes/apps/monitoring/grafana-operator/instance/dashboards/sleep-dashboard.json
@@ -1,0 +1,1334 @@
+{
+  "uid": "sleep-apple-health",
+  "title": "Sleep",
+  "description": "Sleep history backfilled from Apple Health, plus nightly vitals",
+  "tags": ["health", "sleep"],
+  "timezone": "browser",
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 41,
+  "refresh": "",
+  "time": {
+    "from": "now-1y",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "source",
+        "label": "Source",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "health-metrics"
+        },
+        "definition": "label_values(health_sleep_asleep_hours, source)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(health_sleep_asleep_hours, source)",
+          "refId": "A"
+        },
+        "includeAll": true,
+        "multi": true,
+        "refresh": 1,
+        "sort": 1,
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Asleep (30d avg)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "decimals": 2,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "colorMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "R",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_asleep_hours{source=~\"$source\"}[30d]))",
+          "legendFormat": "Asleep (30d avg)",
+          "instant": true,
+          "range": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Deep (30d avg)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "decimals": 2,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "colorMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "P",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_deep_hours{source=~\"$source\"}[30d]))",
+          "legendFormat": "Deep (30d avg)",
+          "instant": true,
+          "range": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "REM (30d avg)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "decimals": 2,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "colorMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "O",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_rem_hours{source=~\"$source\"}[30d]))",
+          "legendFormat": "REM (30d avg)",
+          "instant": true,
+          "range": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Efficiency (30d avg)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "colorMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "X",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_efficiency_percent{source=~\"$source\"}[30d]))",
+          "legendFormat": "Efficiency (30d avg)",
+          "instant": true,
+          "range": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Resting HR (30d avg)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "colorMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_resting_heart_rate_bpm[30d]))",
+          "legendFormat": "Resting HR (30d avg)",
+          "instant": true,
+          "range": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "stat",
+      "title": "Nights in range",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "text"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "colorMode": "value",
+        "orientation": "auto"
+      },
+      "targets": [
+        {
+          "refId": "Y",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "sum(count_over_time(health_sleep_asleep_hours{source=~\"$source\"}[$__range]))",
+          "legendFormat": "Nights in range",
+          "instant": true,
+          "range": false,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Sleep stages per night",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "description": "Stacked hypnogram totals for the main sleep session of each night. Nights before 2022 only carry undifferentiated 'asleep' \u2014 see the note at the bottom.",
+      "interval": "1d",
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "decimals": 2,
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 0,
+            "fillOpacity": 85,
+            "showPoints": "never",
+            "pointSize": 4,
+            "spanNulls": false,
+            "axisSoftMin": null,
+            "lineInterpolation": "linear",
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "Deep",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "Z",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "REM",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_core_hours{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "Core / light",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "O",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_asleep_unspecified_hours{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "Asleep (unstaged)",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_awake_hours{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "Awake",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Total sleep",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "description": "",
+      "interval": "1d",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "decimals": 2,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "always",
+            "pointSize": 4,
+            "spanNulls": false,
+            "axisSoftMin": null,
+            "lineInterpolation": "smooth"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "Asleep",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_asleep_hours{source=~\"$source\"}[7d] offset -12h))",
+          "legendFormat": "7-night avg",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "D",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_asleep_hours{source=~\"$source\"}[30d] offset -12h))",
+          "legendFormat": "30-night avg",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_in_bed_hours{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "In bed",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Efficiency & latency",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "description": "Efficiency = asleep / in bed. Latency = time from getting in bed to first asleep segment.",
+      "interval": "1d",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "pointSize": 4,
+            "spanNulls": false,
+            "axisSoftMin": null,
+            "lineInterpolation": "smooth"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "I",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_efficiency_percent{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "Efficiency %",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "J",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_efficiency_percent{source=~\"$source\"}[30d] offset -12h))",
+          "legendFormat": "Efficiency % (30-night avg)",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "F",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_latency_minutes{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "Latency (min)",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Deep sleep",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "description": "",
+      "interval": "1d",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 21
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "decimals": 2,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "always",
+            "pointSize": 4,
+            "spanNulls": false,
+            "axisSoftMin": null,
+            "lineInterpolation": "smooth"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "Deep",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_deep_hours{source=~\"$source\"}[7d] offset -12h))",
+          "legendFormat": "7-night avg",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_deep_hours{source=~\"$source\"}[30d] offset -12h))",
+          "legendFormat": "30-night avg",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "REM sleep",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "description": "",
+      "interval": "1d",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 21
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "decimals": 2,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "always",
+            "pointSize": 4,
+            "spanNulls": false,
+            "axisSoftMin": null,
+            "lineInterpolation": "smooth"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "Z",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "REM",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "Z",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_rem_hours{source=~\"$source\"}[7d] offset -12h))",
+          "legendFormat": "7-night avg",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_rem_hours{source=~\"$source\"}[30d] offset -12h))",
+          "legendFormat": "30-night avg",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Stage share of asleep time",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "description": "",
+      "interval": "1d",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 21
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 1,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "pointSize": 4,
+            "spanNulls": false,
+            "axisSoftMin": null,
+            "lineInterpolation": "smooth"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "L",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "100 * avg(avg_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h)) / avg(avg_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "Deep %",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "K",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "100 * avg(avg_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -12h)) / avg(avg_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "REM %",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "L",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "100 * avg(avg_over_time(health_sleep_core_hours{source=~\"$source\"}[1d] offset -12h)) / avg(avg_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "Core %",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Bedtime & wake time",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "description": "Hours relative to midnight of the wake day: 23:30 the previous evening reads as -0.5.",
+      "interval": "1d",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "decimals": 2,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "always",
+            "pointSize": 4,
+            "spanNulls": false,
+            "axisSoftMin": null,
+            "lineInterpolation": "smooth"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "K",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_bedtime_offset_hours{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "Bedtime (h from midnight)",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "E",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_waketime_hours{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "Wake time (h after midnight)",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "Heart rate",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "description": "bpm",
+      "interval": "1d",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "pointSize": 4,
+            "spanNulls": false,
+            "axisSoftMin": null,
+            "lineInterpolation": "smooth"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "E",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_heart_rate_bpm{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "Mean during sleep",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "I",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_heart_rate_min_bpm{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "Lowest during sleep",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "N",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_resting_heart_rate_bpm[1d] offset -12h))",
+          "legendFormat": "Resting (daily)",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "HRV (SDNN)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "description": "",
+      "interval": "1d",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 37
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "always",
+            "pointSize": 4,
+            "spanNulls": false,
+            "axisSoftMin": null,
+            "lineInterpolation": "smooth"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_hrv_sdnn_ms{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "HRV",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_hrv_sdnn_ms{source=~\"$source\"}[30d] offset -12h))",
+          "legendFormat": "30-night avg",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "Respiration & blood oxygen",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "description": "",
+      "interval": "1d",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 37
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 1,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "pointSize": 4,
+            "spanNulls": false,
+            "axisSoftMin": null,
+            "lineInterpolation": "smooth"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "K",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_respiratory_rate_bpm{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "Respiratory rate (/min)",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "P",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_oxygen_saturation_percent{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "SpO2 %",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "Sleeping wrist temperature",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "description": "",
+      "interval": "1d",
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 37
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "decimals": 2,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "always",
+            "pointSize": 4,
+            "spanNulls": false,
+            "axisSoftMin": null,
+            "lineInterpolation": "smooth"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "P",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(avg_over_time(health_sleep_wrist_temperature_celsius{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "Wrist temp",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 18,
+      "type": "text",
+      "title": "About this data",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 45
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "Backfilled from an Apple Health **Export All Health Data** archive into the `vmsingle-health` instance (100y retention) \u2014 see `kubernetes/apps/monitoring/health-metrics`.\n\n- **Nights** run noon-to-noon and are labelled with the **wake-up date**, matching the Health app.\n- Each night uses its **longest sleep session**; extra sessions are counted separately as `health_sleep_nap_hours`.\n- **Stage data (deep/REM/core) only exists from 2022 onward** \u2014 earlier nights came from AutoSleep, which writes undifferentiated `asleep`, and Apple Watch staging needs watchOS 9. Pre-2022 nights therefore appear in the stacked chart as *Asleep (unstaged)*.\n- Sources overlap in time (AutoSleep 2019-2024, Apple Watch 2020-2026, Oura 2026-). Use the **Source** picker to compare one against another; with several selected, values are averaged.\n- Oura writes some nights twice ~29s apart; the importer flattens overlapping segments so stage totals can never exceed the session length."
+      }
+    }
+  ]
+}

--- a/kubernetes/apps/monitoring/grafana-operator/instance/dashboards/sleep.yaml
+++ b/kubernetes/apps/monitoring/grafana-operator/instance/dashboards/sleep.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: sleep
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  configMapRef:
+    name: sleep-dashboard
+    key: sleep-dashboard.json

--- a/kubernetes/apps/monitoring/grafana-operator/instance/grafanadatasource.yaml
+++ b/kubernetes/apps/monitoring/grafana-operator/instance/grafanadatasource.yaml
@@ -21,6 +21,26 @@ spec:
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource
 metadata:
+  name: health-metrics
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasource:
+    name: HealthMetrics
+    type: prometheus
+    uid: health-metrics
+    access: proxy
+    # Long-retention instance holding backfilled Apple Health history; kept apart
+    # from the 1-month cluster metrics store (see apps/monitoring/health-metrics).
+    url: http://vmsingle-health.monitoring.svc.cluster.local:8428
+    jsonData:
+      prometheusType: Prometheus
+      timeInterval: 1d
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
   name: victorialogs
 spec:
   instanceSelector:

--- a/kubernetes/apps/monitoring/health-metrics/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/health-metrics/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - ./vmsingle.yaml

--- a/kubernetes/apps/monitoring/health-metrics/app/vmsingle.yaml
+++ b/kubernetes/apps/monitoring/health-metrics/app/vmsingle.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMSingle
+metadata:
+  name: health
+spec:
+  # Deliberately separate from the k8s-stack vmsingle, which runs a 1-month
+  # retention (~13GB on disk for that one month). VictoriaMetrics drops samples
+  # whose timestamp falls outside the retention window at ingestion time
+  # (vm_rows_ignored_total{reason="too_small_timestamp"}), so backfilled Apple
+  # Health history from 2019 cannot land there. Raising that instance's retention
+  # far enough would cost ~1TB, and per-metric retention (-retentionFilter) plus
+  # downsampling are both Enterprise-only. This instance holds ~14k hand-imported
+  # samples (~0.3MB) instead.
+  retentionPeriod: "100y"
+  removePvcAfterDelete: false
+  extraArgs:
+    # Makes re-running the importer idempotent: repeat samples landing on the same
+    # per-night timestamp collapse to the last one instead of stacking up.
+    dedup.minScrapeInterval: 1m
+  storage:
+    accessModes:
+      - ReadWriteOnce
+    storageClassName: ceph-block
+    resources:
+      requests:
+        storage: 1Gi
+  resources:
+    requests:
+      cpu: 10m
+      memory: 128Mi
+    limits:
+      memory: 512Mi

--- a/kubernetes/apps/monitoring/health-metrics/ks.yaml
+++ b/kubernetes/apps/monitoring/health-metrics/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app health-metrics
+spec:
+  targetNamespace: monitoring
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: victoriametrics
+      namespace: monitoring
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  path: ./kubernetes/apps/monitoring/health-metrics/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: monitoring
 resources:
   - ./namespace.yaml
   - ./victoriametrics/ks.yaml
+  - ./health-metrics/ks.yaml
   - ./grafana-operator/ks.yaml
   - ./grafana-image-renderer/ks.yaml
   - ./gatus/ks.yaml

--- a/scripts/apple-health-sleep-import.py
+++ b/scripts/apple-health-sleep-import.py
@@ -1,0 +1,435 @@
+#!/usr/bin/env python3
+"""Parse Apple Health export.zip / export.xml sleep data.
+
+Stats mode (default) reports what's in the export without touching anything.
+--out writes VictoriaMetrics /api/v1/import JSON-lines; --url POSTs them.
+
+Stdlib only. Usage:
+    ./apple_health_sleep.py ~/Downloads/export.zip
+    ./apple_health_sleep.py ~/Downloads/export.zip --out /tmp/sleep.jsonl
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import io
+import json
+import sys
+import urllib.request
+import zipfile
+from collections import defaultdict
+from datetime import datetime, timedelta
+from xml.etree import ElementTree as ET
+
+SLEEP_TYPE = "HKCategoryTypeIdentifierSleepAnalysis"
+
+# HKCategoryValueSleepAnalysis* suffix -> our stage name.
+# "Asleep" (no suffix) is the pre-watchOS-9 undifferentiated value; anything
+# tracked before Sept 2022 (or by a source that doesn't do staging) lands there.
+STAGES = {
+    "InBed": "in_bed",
+    "Asleep": "asleep_unspecified",
+    "AsleepUnspecified": "asleep_unspecified",
+    "AsleepCore": "core",
+    "AsleepDeep": "deep",
+    "AsleepREM": "rem",
+    "Awake": "awake",
+}
+ASLEEP_STAGES = ("core", "deep", "rem", "asleep_unspecified")
+
+# Nightly quantity types worth carrying alongside the stages.
+QUANTITIES = {
+    "HKQuantityTypeIdentifierHeartRate": "heart_rate_bpm",
+    "HKQuantityTypeIdentifierHeartRateVariabilitySDNN": "hrv_sdnn_ms",
+    "HKQuantityTypeIdentifierRestingHeartRate": "resting_heart_rate_bpm",
+    "HKQuantityTypeIdentifierRespiratoryRate": "respiratory_rate_bpm",
+    "HKQuantityTypeIdentifierOxygenSaturation": "oxygen_saturation_percent",
+    "HKQuantityTypeIdentifierAppleSleepingWristTemperature": "wrist_temperature_celsius",
+}
+
+# A gap longer than this between segments starts a new sleep session.
+SESSION_GAP = timedelta(minutes=60)
+
+
+def parse_ts(raw: str) -> datetime:
+    # "2026-07-29 23:34:11 +0200"
+    return datetime.strptime(raw, "%Y-%m-%d %H:%M:%S %z")
+
+
+def night_of(start: datetime) -> str:
+    """Apple's noon-to-noon sleep day: a session belongs to its wake-up date."""
+    return (start + timedelta(hours=12)).date().isoformat()
+
+
+def open_xml(path: str) -> io.BufferedIOBase:
+    if path.endswith(".zip"):
+        zf = zipfile.ZipFile(path)
+        name = next(
+            (n for n in zf.namelist() if n.endswith("export.xml") and "cda" not in n.lower()),
+            None,
+        )
+        if name is None:
+            sys.exit(f"no export.xml inside {path} (found: {zf.namelist()[:5]})")
+        return zf.open(name)
+    if path.endswith(".gz"):
+        return gzip.open(path, "rb")
+    return open(path, "rb")
+
+
+def iter_records(path: str, types: set[str]):
+    """Stream <Record> elements of the given types, keeping memory flat."""
+    handle = open_xml(path)
+    try:
+        context = ET.iterparse(handle, events=("start", "end"))
+        _, root = next(context)
+        seen = 0
+        for event, elem in context:
+            if event != "end" or elem.tag != "Record":
+                continue
+            if elem.get("type") in types:
+                yield elem
+            elem.clear()
+            seen += 1
+            if seen % 20000 == 0:
+                root.clear()
+    finally:
+        handle.close()
+
+
+# Stage precedence when two segments start at the same instant. A specific
+# asleep stage beats an unspecified one, and any asleep stage beats Awake.
+PRIORITY = {"deep": 4, "rem": 3, "core": 2, "asleep_unspecified": 1, "awake": 0}
+
+
+def flatten(segments: list[tuple[datetime, datetime, str]]) -> dict[str, float]:
+    """Collapse possibly-overlapping stage segments into non-overlapping totals.
+
+    Oura writes some nights twice, offset by ~29s (two interleaved copies of the
+    same hypnogram), so naively summing segment durations inflates a night to
+    ~1.8x its real length. Sweeping the timeline and letting the most recently
+    started segment own each instant collapses duplicate coverage, and guarantees
+    sum(stages) <= session span.
+    """
+    import heapq
+
+    if not segments:
+        return {}
+    points = sorted({t for start, end, _ in segments for t in (start, end)})
+    ordered = sorted(segments, key=lambda s: s[0])
+    totals: dict[str, float] = defaultdict(float)
+    active: list[tuple[float, int, datetime, str]] = []
+    idx = 0
+
+    for a, b in zip(points, points[1:]):
+        while idx < len(ordered) and ordered[idx][0] <= a:
+            start, end, stage = ordered[idx]
+            heapq.heappush(active, (-start.timestamp(), -PRIORITY[stage], end, stage))
+            idx += 1
+        while active and active[0][2] <= a:
+            heapq.heappop(active)
+        if active:
+            totals[active[0][3]] += (b - a).total_seconds() / 3600
+    return totals
+
+
+def merge_spans(spans: list[tuple[datetime, datetime]]) -> float:
+    """Total hours covered by the union of possibly-overlapping intervals."""
+    total = 0.0
+    current_start = current_end = None
+    for start, end in sorted(spans):
+        if current_end is None or start > current_end:
+            if current_end is not None:
+                total += (current_end - current_start).total_seconds() / 3600
+            current_start, current_end = start, end
+        else:
+            current_end = max(current_end, end)
+    if current_end is not None:
+        total += (current_end - current_start).total_seconds() / 3600
+    return total
+
+
+class Session:
+    __slots__ = ("source", "start", "end", "_sleep", "_bed", "_stages")
+
+    def __init__(self, source: str, start: datetime):
+        self.source = source
+        self.start = start
+        self.end = start
+        self._sleep: list[tuple[datetime, datetime, str]] = []
+        self._bed: list[tuple[datetime, datetime]] = []
+        self._stages: dict[str, float] | None = None
+
+    def add(self, stage: str, start: datetime, end: datetime) -> None:
+        self.end = max(self.end, end)
+        if stage == "in_bed":
+            self._bed.append((start, end))
+        else:
+            self._sleep.append((start, end, stage))
+            self.start = min(self.start, start)
+
+    @property
+    def stages(self) -> dict[str, float]:
+        if self._stages is None:
+            self._stages = defaultdict(float, flatten(self._sleep))
+        return self._stages
+
+    @property
+    def asleep(self) -> float:
+        return sum(self.stages[s] for s in ASLEEP_STAGES)
+
+    @property
+    def in_bed(self) -> float:
+        return merge_spans(self._bed) or (self.end - self.start).total_seconds() / 3600
+
+    @property
+    def in_bed_start(self) -> datetime | None:
+        return min((s for s, _ in self._bed), default=None)
+
+    @property
+    def has_stages(self) -> bool:
+        return any(self.stages[s] for s in ("core", "deep", "rem"))
+
+
+def collect_sessions(path: str) -> list[Session]:
+    """Group raw sleep segments into per-source sessions."""
+    per_source: dict[str, list[tuple[datetime, datetime, str]]] = defaultdict(list)
+    for elem in iter_records(path, {SLEEP_TYPE}):
+        value = (elem.get("value") or "").replace("HKCategoryValueSleepAnalysis", "")
+        stage = STAGES.get(value)
+        if stage is None:
+            continue
+        per_source[elem.get("sourceName") or "unknown"].append(
+            (parse_ts(elem.get("startDate")), parse_ts(elem.get("endDate")), stage)
+        )
+
+    sessions: list[Session] = []
+    for source, segments in per_source.items():
+        segments.sort(key=lambda s: s[0])
+        current: Session | None = None
+        for start, end, stage in segments:
+            if current is None or start - current.end > SESSION_GAP:
+                current = Session(source, start)
+                sessions.append(current)
+            current.add(stage, start, end)
+
+    # Some sources (old iOS "Clock" bedtime, Ominous) only ever write InBed
+    # intervals — no asleep segments at all, so they'd contribute 0h nights.
+    dropped = {s.source for s in sessions if s.asleep == 0} - {s.source for s in sessions if s.asleep}
+    if dropped:
+        print(f"note: ignoring InBed-only source(s): {', '.join(sorted(dropped))}", file=sys.stderr)
+    return [s for s in sessions if s.asleep > 0]
+
+
+def collect_quantities(path: str, windows: list[tuple[datetime, datetime, str, str]]):
+    """Average each quantity type over each (main) sleep session window.
+
+    windows: (start, end, night, source) for main sessions only.
+    Returns {(night, source, metric): mean_value} plus min heart rate.
+    """
+    windows.sort(key=lambda w: w[0])
+    starts = [w[0] for w in windows]
+    acc: dict[tuple[str, str, str], list[float]] = defaultdict(list)
+    daily: dict[tuple[str, str], float] = {}
+
+    import bisect
+
+    for elem in iter_records(path, set(QUANTITIES)):
+        metric = QUANTITIES[elem.get("type")]
+        try:
+            value = float(elem.get("value"))
+        except (TypeError, ValueError):
+            continue
+        if metric == "oxygen_saturation_percent":
+            value *= 100  # HealthKit stores SpO2 as a 0-1 fraction
+        ts = parse_ts(elem.get("startDate"))
+
+        if metric == "resting_heart_rate_bpm":
+            # Daily summary sample, not tied to a session window.
+            daily[(ts.date().isoformat(), metric)] = value
+            continue
+
+        idx = bisect.bisect_right(starts, ts) - 1
+        if idx < 0:
+            continue
+        start, end, night, source = windows[idx]
+        if ts <= end:
+            acc[(night, source, metric)].append(value)
+
+    out: dict[tuple[str, str, str], float] = {}
+    for (night, source, metric), values in acc.items():
+        out[(night, source, metric)] = sum(values) / len(values)
+        if metric == "heart_rate_bpm":
+            out[(night, source, "heart_rate_min_bpm")] = min(values)
+    for (night, metric), value in daily.items():
+        out[(night, "daily", metric)] = value
+    return out
+
+
+def build_series(sessions: list[Session], quantities) -> dict[tuple[str, tuple], dict]:
+    """Fold sessions + quantities into VM import series keyed by (metric, labels)."""
+    series: dict[tuple[str, tuple], dict[str, list]] = defaultdict(
+        lambda: {"values": [], "timestamps": []}
+    )
+
+    def emit(metric: str, source: str, night: str, tz, value: float) -> None:
+        noon = datetime.fromisoformat(night).replace(hour=12, tzinfo=tz)
+        key = (f"health_{metric}", (("source", source),))
+        series[key]["values"].append(round(value, 4))
+        series[key]["timestamps"].append(int(noon.timestamp() * 1000))
+
+    # Main session per (night, source); everything else counts as a nap.
+    by_night: dict[tuple[str, str], list[Session]] = defaultdict(list)
+    for s in sessions:
+        by_night[(night_of(s.start), s.source)].append(s)
+
+    for (night, source), group in sorted(by_night.items()):
+        main = max(group, key=lambda s: s.asleep)
+        tz = main.start.tzinfo
+        midnight = datetime.fromisoformat(night).replace(tzinfo=tz)
+
+        emit("sleep_asleep_hours", source, night, tz, main.asleep)
+        emit("sleep_in_bed_hours", source, night, tz, main.in_bed)
+        for stage in ("deep", "rem", "core", "awake", "asleep_unspecified"):
+            if main.stages[stage]:
+                emit(f"sleep_{stage}_hours", source, night, tz, main.stages[stage])
+        if main.in_bed:
+            emit(
+                "sleep_efficiency_percent", source, night, tz,
+                min(100.0, 100 * main.asleep / main.in_bed),
+            )
+        # Bedtime as hours relative to the wake day's midnight (23:30 -> -0.5).
+        emit(
+            "sleep_bedtime_offset_hours", source, night, tz,
+            (main.start - midnight).total_seconds() / 3600,
+        )
+        emit(
+            "sleep_waketime_hours", source, night, tz,
+            (main.end - midnight).total_seconds() / 3600,
+        )
+        if main.in_bed_start:
+            emit(
+                "sleep_latency_minutes", source, night, tz,
+                max(0.0, (main.start - main.in_bed_start).total_seconds() / 60),
+            )
+        naps = sum(s.asleep for s in group if s is not main)
+        if naps:
+            emit("sleep_nap_hours", source, night, tz, naps)
+        emit("sleep_sessions", source, night, tz, float(len(group)))
+
+        for metric in (
+            "heart_rate_bpm", "heart_rate_min_bpm", "hrv_sdnn_ms",
+            "respiratory_rate_bpm", "oxygen_saturation_percent",
+            "wrist_temperature_celsius",
+        ):
+            value = quantities.get((night, source, metric))
+            if value is not None:
+                emit(f"sleep_{metric}", source, night, tz, value)
+
+        rhr = quantities.get((night, "daily", "resting_heart_rate_bpm"))
+        if rhr is not None:
+            emit("resting_heart_rate_bpm", "daily", night, tz, rhr)
+
+    return series
+
+
+def print_stats(sessions: list[Session], series) -> None:
+    by_night: dict[tuple[str, str], list[Session]] = defaultdict(list)
+    for s in sessions:
+        by_night[(night_of(s.start), s.source)].append(s)
+    mains = {k: max(v, key=lambda s: s.asleep) for k, v in by_night.items()}
+
+    nights = sorted({night for night, _ in mains})
+    raw = sum(len(s._sleep) + len(s._bed) for s in sessions)
+    over = [
+        (night, source) for (night, source), m in mains.items()
+        if m.in_bed and m.asleep / m.in_bed > 1.001
+    ]
+    print(f"\nsleep segments : {raw:,} across {len(sessions):,} sessions")
+    print(f"nights with efficiency > 100% (should be 0): {len(over)}")
+    print(f"nights         : {len(nights):,}  ({nights[0]} -> {nights[-1]})" if nights else "nights: 0")
+
+    print("\nper source:")
+    per_source: dict[str, list[Session]] = defaultdict(list)
+    for (_, source), main in mains.items():
+        per_source[source].append(main)
+    for source, mains_s in sorted(per_source.items(), key=lambda kv: -len(kv[1])):
+        staged = sum(1 for m in mains_s if m.has_stages)
+        avg = sum(m.asleep for m in mains_s) / len(mains_s)
+        first = min(night_of(m.start) for m in mains_s)
+        last = max(night_of(m.start) for m in mains_s)
+        print(
+            f"  {source:<24} {len(mains_s):>5} nights  {first} -> {last}"
+            f"  stages: {staged:>5} ({100 * staged / len(mains_s):.0f}%)"
+            f"  avg asleep: {avg:.2f}h"
+        )
+
+    samples = sum(len(v["values"]) for v in series.values())
+    print(f"\nseries         : {len(series):,}")
+    print(f"samples        : {samples:,}")
+    print(f"import payload : ~{sum(len(json.dumps({'metric': dict(k[1], __name__=k[0]), **v})) for k, v in series.items()) / 1e6:.1f} MB uncompressed")
+
+    print("\nlast 7 nights (main session per source):")
+    print(f"  {'night':<12} {'source':<22} {'asleep':>7} {'deep':>6} {'rem':>6} {'core':>6} {'awake':>6} {'eff':>5}")
+    for night, source in sorted(mains)[-7:]:
+        m = mains[(night, source)]
+        eff = 100 * m.asleep / m.in_bed if m.in_bed else 0
+        print(
+            f"  {night:<12} {source:<22} {m.asleep:>6.2f}h {m.stages['deep']:>5.2f}h"
+            f" {m.stages['rem']:>5.2f}h {m.stages['core']:>5.2f}h {m.stages['awake']:>5.2f}h {eff:>4.0f}%"
+        )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("export", help="export.zip, export.xml or export.xml.gz")
+    ap.add_argument("--out", help="write VictoriaMetrics import JSON-lines here")
+    ap.add_argument("--url", help="POST to a VM /api/v1/import endpoint")
+    ap.add_argument("--no-quantities", action="store_true", help="skip the HR/HRV/SpO2 pass")
+    args = ap.parse_args()
+
+    print(f"pass 1/2: sleep records from {args.export} ...", file=sys.stderr)
+    sessions = collect_sessions(args.export)
+    if not sessions:
+        sys.exit("no sleep records found in the export")
+
+    quantities: dict = {}
+    if not args.no_quantities:
+        print("pass 2/2: heart rate / HRV / respiratory / SpO2 ...", file=sys.stderr)
+        by_night: dict[tuple[str, str], list[Session]] = defaultdict(list)
+        for s in sessions:
+            by_night[(night_of(s.start), s.source)].append(s)
+        windows = [
+            (main.start, main.end, night, source)
+            for (night, source), group in by_night.items()
+            for main in [max(group, key=lambda s: s.asleep)]
+        ]
+        quantities = collect_quantities(args.export, windows)
+
+    series = build_series(sessions, quantities)
+    print_stats(sessions, series)
+
+    if not (args.out or args.url):
+        return
+
+    lines = [
+        json.dumps({"metric": {"__name__": name, **dict(labels)}, **payload})
+        for (name, labels), payload in sorted(series.items())
+    ]
+    body = ("\n".join(lines) + "\n").encode()
+    if args.out:
+        with open(args.out, "wb") as fh:
+            fh.write(body)
+        print(f"\nwrote {args.out} ({len(body) / 1e6:.1f} MB, {len(lines)} series)")
+    if args.url:
+        req = urllib.request.Request(
+            args.url.rstrip("/") + "/api/v1/import",
+            data=body,
+            headers={"Content-Type": "application/x-ndjson"},
+        )
+        with urllib.request.urlopen(req) as resp:
+            print(f"POST {args.url} -> {resp.status}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Backfills ~950 nights of sleep history (2019-04-21 → 2026-07-30) out of an Apple Health export, and puts a dashboard over it.

## Why a second VictoriaMetrics instance

The cluster `vmsingle` runs `retentionPeriod: 1` (one month, ~13GB on disk for that month), and VictoriaMetrics **drops samples whose timestamp falls outside the retention window at ingestion time** — so 2019 data can never land there regardless of how small it is. Raising that instance's retention to cover 7 years would cost roughly 1TB: there's no downsampling in OSS, and per-metric retention (`-retentionFilter`) is Enterprise-only.

So: a dedicated `VMSingle` with 100y retention holding ~14k samples (~0.3MB), 1Gi PVC, 128Mi requested. `dedup.minScrapeInterval: 1m` makes re-imports idempotent.

No VolSync wiring — the data is fully reproducible from a fresh Apple Health export.

## What's in the data

| source | nights | range | stages |
|---|---|---|---|
| AutoSleep | 507 | 2019-04-21 → 2024-02-18 | none |
| Apple Watch | 407 | 2020-09-17 → 2026-06-15 | 99% |
| Oura | 38 | 2026-06-23 → 2026-07-30 | 100% |
| NapBot | 16 | 2022-05-10 → 2022-06-05 | none |

Deep/REM/core only exist from 2022 on (AutoSleep writes undifferentiated "asleep"; Apple Watch staging needs watchOS 9). Nightly HR/HRV goes back to 2019 for nearly every night. `Clock` and `Ominous` are ignored — they only ever wrote `InBed`.

## Importer notes

`scripts/apple-health-sleep-import.py` (stdlib only) streams `export.xml`, and:

- groups segments into sessions (>60min gap starts a new one), assigns each to a **noon-to-noon night labelled by wake date**, matching the Health app
- takes the longest session per night as the main sleep; extra sessions become `health_sleep_nap_hours`
- **flattens overlapping segments.** Oura writes some nights twice, offset ~29s — two interleaved copies of one hypnogram. Summing durations inflated one night to 10.77h asleep at 136% efficiency. Sweeping the timeline with last-writer-wins-per-instant fixes it (0 nights over 100% efficiency now, Oura's average dropped 8.26h → 7.32h, in line with the other sources)

Validated against the live Oura sensors in Home Assistant for 2026-07-30 — total 7.20h, deep 2.07h, REM 2.02h, core 3.11h, efficiency 82% all match exactly.

## Test plan

- [x] `kustomize build` on `health-metrics/app` and `grafana-operator/instance`
- [x] `yamllint` clean
- [x] MetricsQL `offset -12h` alignment verified against the running vmsingle
- [x] after merge: `vmsingle-health` pod up, import pushed, dashboard renders