### PR TITLE
fix(monitoring): sleep dashboard panels and vmsingle memory limit

### DIFF
--- a/kubernetes/apps/monitoring/grafana-operator/instance/dashboards/sleep-dashboard.json
+++ b/kubernetes/apps/monitoring/grafana-operator/instance/dashboards/sleep-dashboard.json
@@ -89,7 +89,7 @@
       },
       "targets": [
         {
-          "refId": "R",
+          "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -150,7 +150,7 @@
       },
       "targets": [
         {
-          "refId": "P",
+          "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -211,7 +211,7 @@
       },
       "targets": [
         {
-          "refId": "O",
+          "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -272,7 +272,7 @@
       },
       "targets": [
         {
-          "refId": "X",
+          "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -333,7 +333,7 @@
       },
       "targets": [
         {
-          "refId": "C",
+          "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -394,7 +394,7 @@
       },
       "targets": [
         {
-          "refId": "Y",
+          "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -470,7 +470,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "Z",
+          "refId": "B",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -482,7 +482,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "A",
+          "refId": "C",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -494,7 +494,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "O",
+          "refId": "D",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -506,7 +506,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "B",
+          "refId": "E",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -566,7 +566,7 @@
       },
       "targets": [
         {
-          "refId": "C",
+          "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -578,7 +578,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "C",
+          "refId": "B",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -590,7 +590,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "D",
+          "refId": "C",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -602,7 +602,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "C",
+          "refId": "D",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -646,7 +646,20 @@
             "lineInterpolation": "smooth"
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Latency (min)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "m"
+              }
+            ]
+          }
+        ]
       },
       "options": {
         "legend": {
@@ -662,7 +675,7 @@
       },
       "targets": [
         {
-          "refId": "I",
+          "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -674,7 +687,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "J",
+          "refId": "B",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -686,7 +699,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "F",
+          "refId": "C",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -758,7 +771,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "A",
+          "refId": "B",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -770,7 +783,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "B",
+          "refId": "C",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -830,7 +843,7 @@
       },
       "targets": [
         {
-          "refId": "Z",
+          "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -842,7 +855,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "Z",
+          "refId": "B",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -854,7 +867,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "A",
+          "refId": "C",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -914,7 +927,7 @@
       },
       "targets": [
         {
-          "refId": "L",
+          "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -926,7 +939,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "K",
+          "refId": "B",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -938,7 +951,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "L",
+          "refId": "C",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -998,7 +1011,7 @@
       },
       "targets": [
         {
-          "refId": "K",
+          "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -1010,7 +1023,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "E",
+          "refId": "B",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -1070,7 +1083,7 @@
       },
       "targets": [
         {
-          "refId": "E",
+          "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -1082,7 +1095,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "I",
+          "refId": "B",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -1094,7 +1107,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "N",
+          "refId": "C",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -1154,7 +1167,7 @@
       },
       "targets": [
         {
-          "refId": "B",
+          "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -1166,7 +1179,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "C",
+          "refId": "B",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -1226,7 +1239,7 @@
       },
       "targets": [
         {
-          "refId": "K",
+          "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -1238,7 +1251,7 @@
           "editorMode": "code"
         },
         {
-          "refId": "P",
+          "refId": "B",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"
@@ -1298,7 +1311,7 @@
       },
       "targets": [
         {
-          "refId": "P",
+          "refId": "A",
           "datasource": {
             "type": "prometheus",
             "uid": "health-metrics"

--- a/kubernetes/apps/monitoring/health-metrics/app/vmsingle.yaml
+++ b/kubernetes/apps/monitoring/health-metrics/app/vmsingle.yaml
@@ -28,6 +28,11 @@ spec:
   resources:
     requests:
       cpu: 10m
-      memory: 128Mi
+      memory: 256Mi
     limits:
-      memory: 512Mi
+      # 512Mi got OOMKilled. The dataset is tiny, but 100y retention means one
+      # monthly partition per month of history (~88 of them for 2019-2026), each
+      # holding index structures, and VictoriaMetrics sizes its caches off the
+      # cgroup limit — so the floor is set by partition count, not sample count.
+      # delete_series reindexing is the peak.
+      memory: 1Gi

--- a/scripts/apple-health-sleep-import.py
+++ b/scripts/apple-health-sleep-import.py
@@ -199,7 +199,10 @@ def collect_sessions(path: str) -> list[Session]:
         stage = STAGES.get(value)
         if stage is None:
             continue
-        per_source[elem.get("sourceName") or "unknown"].append(
+        # Apple writes "Apple Watch" with a non-breaking space, which makes any
+        # hand-written {source="...Apple Watch"} selector silently match nothing.
+        source = (elem.get("sourceName") or "unknown").replace(" ", " ")
+        per_source[source].append(
             (parse_ts(elem.get("startDate")), parse_ts(elem.get("endDate")), stage)
         )
 


### PR DESCRIPTION
Follow-up to #3914.

## Five panels showed "No data"

`Sleep stages per night`, `Total sleep`, `Deep sleep`, `REM sleep` and `Stage share of asleep time` all errored out. The dashboard generator derived each target's `refId` from `len(expr) % 26`, so two queries of the same length inside one panel got the same refId and Grafana rejects the panel:

- `deep[1d]` vs `deep[7d]` — identical length
- `health_sleep_asleep_hours` vs `health_sleep_in_bed_hours` — both 25 chars
- `deep %` vs `core %` — identical length

Every panel whose queries happened to differ in length rendered fine, which is why the failure looked arbitrary. refIds are now sequential per panel (`A`, `B`, `C`, …).

## Also

- **`Latency (min)` inherited the panel's `percent` unit** and displayed as `0%`; it now has a per-series unit override in minutes.
- **`vmsingle-health` memory limit 512Mi → 1Gi.** The pod was OOMKilled (exit 137) during `delete_series` reindexing. The dataset is 0.3MB, but 100y retention creates one monthly partition per month of history (~88 for 2019–2026), each carrying index structures, and VictoriaMetrics sizes its caches off the cgroup limit — so the memory floor comes from partition count, not sample count. Request raised 128Mi → 256Mi to match the real working set.
- **Importer normalizes the non-breaking space** Apple writes inside "Apple Watch". The label was `Nikola’s Apple\xa0Watch`, so a hand-typed `{source="Nikola’s Apple Watch"}` would silently match nothing.

## Test plan

- [x] every panel verified to have unique refIds
- [x] `kustomize build` + `yamllint` clean
- [ ] after merge: wipe the PVC for a known-clean state, re-import, confirm all 18 panels render