### PR TITLE
feat(monitoring): keep the sleep dashboard live from Home Assistant

### DIFF
--- a/kubernetes/apps/monitoring/grafana-operator/instance/dashboards/sleep-dashboard.json
+++ b/kubernetes/apps/monitoring/grafana-operator/instance/dashboards/sleep-dashboard.json
@@ -94,7 +94,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_asleep_hours{source=~\"$source\"}[30d]))",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
           "legendFormat": "Asleep (30d avg)",
           "instant": true,
           "range": false,
@@ -155,7 +155,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_deep_hours{source=~\"$source\"}[30d]))",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
           "legendFormat": "Deep (30d avg)",
           "instant": true,
           "range": false,
@@ -216,7 +216,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_rem_hours{source=~\"$source\"}[30d]))",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
           "legendFormat": "REM (30d avg)",
           "instant": true,
           "range": false,
@@ -277,7 +277,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_efficiency_percent{source=~\"$source\"}[30d]))",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_efficiency_percent{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
           "legendFormat": "Efficiency (30d avg)",
           "instant": true,
           "range": false,
@@ -338,7 +338,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_resting_heart_rate_bpm[30d]))",
+          "expr": "avg_over_time((avg(last_over_time(health_resting_heart_rate_bpm[1d] offset -12h)))[30d:1d])",
           "legendFormat": "Resting HR (30d avg)",
           "instant": true,
           "range": false,
@@ -399,7 +399,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "sum(count_over_time(health_sleep_asleep_hours{source=~\"$source\"}[$__range]))",
+          "expr": "count_over_time((avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h)))[$__range:1d])",
           "legendFormat": "Nights in range",
           "instant": true,
           "range": false,
@@ -463,7 +463,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "Deep",
           "instant": false,
           "range": true,
@@ -475,7 +475,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "REM",
           "instant": false,
           "range": true,
@@ -487,7 +487,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_core_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_core_hours{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "Core / light",
           "instant": false,
           "range": true,
@@ -499,7 +499,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_asleep_unspecified_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_asleep_unspecified_hours{source=~\"$source\"}[1d] offset -12h)) unless avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "Asleep (unstaged)",
           "instant": false,
           "range": true,
@@ -511,7 +511,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_awake_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_awake_hours{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "Awake",
           "instant": false,
           "range": true,
@@ -571,7 +571,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "Asleep",
           "instant": false,
           "range": true,
@@ -583,7 +583,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_asleep_hours{source=~\"$source\"}[7d] offset -12h))",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h)))[7d:1d])",
           "legendFormat": "7-night avg",
           "instant": false,
           "range": true,
@@ -595,7 +595,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_asleep_hours{source=~\"$source\"}[30d] offset -12h))",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
           "legendFormat": "30-night avg",
           "instant": false,
           "range": true,
@@ -607,7 +607,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_in_bed_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_in_bed_hours{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "In bed",
           "instant": false,
           "range": true,
@@ -680,7 +680,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_efficiency_percent{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_efficiency_percent{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "Efficiency %",
           "instant": false,
           "range": true,
@@ -692,7 +692,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_efficiency_percent{source=~\"$source\"}[30d] offset -12h))",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_efficiency_percent{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
           "legendFormat": "Efficiency % (30-night avg)",
           "instant": false,
           "range": true,
@@ -704,7 +704,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_latency_minutes{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_latency_minutes{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "Latency (min)",
           "instant": false,
           "range": true,
@@ -764,7 +764,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "Deep",
           "instant": false,
           "range": true,
@@ -776,7 +776,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_deep_hours{source=~\"$source\"}[7d] offset -12h))",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h)))[7d:1d])",
           "legendFormat": "7-night avg",
           "instant": false,
           "range": true,
@@ -788,7 +788,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_deep_hours{source=~\"$source\"}[30d] offset -12h))",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
           "legendFormat": "30-night avg",
           "instant": false,
           "range": true,
@@ -848,7 +848,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "REM",
           "instant": false,
           "range": true,
@@ -860,7 +860,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_rem_hours{source=~\"$source\"}[7d] offset -12h))",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -12h)))[7d:1d])",
           "legendFormat": "7-night avg",
           "instant": false,
           "range": true,
@@ -872,7 +872,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_rem_hours{source=~\"$source\"}[30d] offset -12h))",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
           "legendFormat": "30-night avg",
           "instant": false,
           "range": true,
@@ -932,7 +932,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "100 * avg(avg_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h)) / avg(avg_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "100 * avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h)) / avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "Deep %",
           "instant": false,
           "range": true,
@@ -944,7 +944,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "100 * avg(avg_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -12h)) / avg(avg_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "100 * avg(last_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -12h)) / avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "REM %",
           "instant": false,
           "range": true,
@@ -956,7 +956,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "100 * avg(avg_over_time(health_sleep_core_hours{source=~\"$source\"}[1d] offset -12h)) / avg(avg_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "100 * avg(last_over_time(health_sleep_core_hours{source=~\"$source\"}[1d] offset -12h)) / avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "Core %",
           "instant": false,
           "range": true,
@@ -1016,7 +1016,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_bedtime_offset_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_bedtime_offset_hours{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "Bedtime (h from midnight)",
           "instant": false,
           "range": true,
@@ -1028,7 +1028,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_waketime_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_waketime_hours{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "Wake time (h after midnight)",
           "instant": false,
           "range": true,
@@ -1088,7 +1088,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_heart_rate_bpm{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_heart_rate_bpm{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "Mean during sleep",
           "instant": false,
           "range": true,
@@ -1100,7 +1100,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_heart_rate_min_bpm{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_heart_rate_min_bpm{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "Lowest during sleep",
           "instant": false,
           "range": true,
@@ -1112,7 +1112,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_resting_heart_rate_bpm[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_resting_heart_rate_bpm[1d] offset -12h))",
           "legendFormat": "Resting (daily)",
           "instant": false,
           "range": true,
@@ -1172,7 +1172,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_hrv_sdnn_ms{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_hrv_ms{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "HRV",
           "instant": false,
           "range": true,
@@ -1184,7 +1184,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_hrv_sdnn_ms{source=~\"$source\"}[30d] offset -12h))",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_hrv_ms{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
           "legendFormat": "30-night avg",
           "instant": false,
           "range": true,
@@ -1244,7 +1244,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_respiratory_rate_bpm{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_respiratory_rate_bpm{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "Respiratory rate (/min)",
           "instant": false,
           "range": true,
@@ -1256,7 +1256,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_oxygen_saturation_percent{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_oxygen_saturation_percent{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "SpO2 %",
           "instant": false,
           "range": true,
@@ -1316,7 +1316,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(avg_over_time(health_sleep_wrist_temperature_celsius{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_wrist_temperature_celsius{source=~\"$source\"}[1d] offset -12h))",
           "legendFormat": "Wrist temp",
           "instant": false,
           "range": true,
@@ -1326,6 +1326,138 @@
     },
     {
       "id": 18,
+      "type": "timeseries",
+      "title": "Sleep score (Oura)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "description": "Oura's own nightly score, arriving via the Home Assistant feed. Apple Health has no equivalent.",
+      "interval": "1d",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 45
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "always",
+            "pointSize": 4,
+            "spanNulls": false,
+            "axisSoftMin": null,
+            "lineInterpolation": "smooth"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(last_over_time(health_sleep_score{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "Score",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_score{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
+          "legendFormat": "30-night avg",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "Naps",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "health-metrics"
+      },
+      "description": "Sleep outside the night's main session.",
+      "interval": "1d",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 45
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "h",
+          "decimals": 2,
+          "custom": {
+            "drawStyle": "bars",
+            "lineWidth": 0,
+            "fillOpacity": 80,
+            "showPoints": "never",
+            "pointSize": 4,
+            "spanNulls": false,
+            "axisSoftMin": null,
+            "lineInterpolation": "linear"
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true,
+          "calcs": ["mean"]
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(last_over_time(health_sleep_nap_hours{source=~\"$source\"}[1d] offset -12h))",
+          "legendFormat": "Nap time",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        }
+      ]
+    },
+    {
+      "id": 20,
       "type": "text",
       "title": "About this data",
       "datasource": {
@@ -1333,14 +1465,14 @@
         "uid": "health-metrics"
       },
       "gridPos": {
-        "h": 6,
+        "h": 7,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 53
       },
       "options": {
         "mode": "markdown",
-        "content": "Backfilled from an Apple Health **Export All Health Data** archive into the `vmsingle-health` instance (100y retention) \u2014 see `kubernetes/apps/monitoring/health-metrics`.\n\n- **Nights** run noon-to-noon and are labelled with the **wake-up date**, matching the Health app.\n- Each night uses its **longest sleep session**; extra sessions are counted separately as `health_sleep_nap_hours`.\n- **Stage data (deep/REM/core) only exists from 2022 onward** \u2014 earlier nights came from AutoSleep, which writes undifferentiated `asleep`, and Apple Watch staging needs watchOS 9. Pre-2022 nights therefore appear in the stacked chart as *Asleep (unstaged)*.\n- Sources overlap in time (AutoSleep 2019-2024, Apple Watch 2020-2026, Oura 2026-). Use the **Source** picker to compare one against another; with several selected, values are averaged.\n- Oura writes some nights twice ~29s apart; the importer flattens overlapping segments so stage totals can never exceed the session length."
+        "content": "Backfilled from an Apple Health **Export All Health Data** archive into the `vmsingle-health` instance (100y retention) \u2014 see `kubernetes/apps/monitoring/health-metrics`.\n\n- **Nights** run noon-to-noon and are labelled with the **wake-up date**, matching the Health app.\n- Each night uses its **longest sleep session**; extra sessions are counted separately as `health_sleep_nap_hours`.\n- **Stage data (deep/REM/core) only exists from 2022 onward** \u2014 earlier nights came from AutoSleep, which writes undifferentiated `asleep`, and Apple Watch staging needs watchOS 9. Pre-2022 nights therefore appear in the stacked chart as *Asleep (unstaged)*.\n- Sources overlap in time (AutoSleep 2019-2024, Apple Watch 2020-2026, Oura 2026-). Use the **Source** picker to compare one against another; with several selected, values are averaged.\n- Oura writes some nights twice ~29s apart; the importer flattens overlapping segments so stage totals can never exceed the session length.\n- **Ongoing nights arrive live** from Home Assistant's Prometheus exporter (`sensor.oura_ring_*`, scraped every 15m and relabelled onto these same metric names), so the dashboard keeps moving without another export.\n- **HRV is not comparable across sources**: Apple Health reports SDNN, Oura reports rMSSD. Pick a single source before reading trends off that panel."
       }
     }
   ]

--- a/kubernetes/apps/monitoring/health-metrics/app/externalsecret.yaml
+++ b/kubernetes/apps/monitoring/health-metrics/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: home-assistant-token
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: home-assistant-token
+    creationPolicy: Owner
+  data:
+    # Same long-lived token the ha-mcp deployment uses; /api/prometheus accepts it.
+    - secretKey: token
+      remoteRef:
+        key: ha-mcp
+        property: token

--- a/kubernetes/apps/monitoring/health-metrics/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/health-metrics/app/kustomization.yaml
@@ -3,4 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: monitoring
 resources:
+  - ./externalsecret.yaml
   - ./vmsingle.yaml
+  - ./vmagent.yaml

--- a/kubernetes/apps/monitoring/health-metrics/app/vmagent.yaml
+++ b/kubernetes/apps/monitoring/health-metrics/app/vmagent.yaml
@@ -1,0 +1,101 @@
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMAgent
+metadata:
+  name: health
+spec:
+  # The scrape config is inline rather than a VMScrapeConfig CR on purpose: the
+  # k8s-stack vmagent runs selectAllByDefault, so a CR here would also be scraped
+  # by that agent and these series would additionally land in the 1-month cluster
+  # instance under a second identity.
+  selectAllByDefault: false
+  # Oura publishes one set of values per night, a few minutes after the ring syncs
+  # in the morning. Scraping often would only restate the same numbers.
+  scrapeInterval: 15m
+  secrets:
+    - home-assistant-token
+  remoteWrite:
+    - url: http://vmsingle-health.monitoring.svc.cluster.local:8428/api/v1/write
+  resources:
+    requests:
+      cpu: 10m
+      memory: 64Mi
+    limits:
+      memory: 192Mi
+  inlineScrapeConfig: |
+    - job_name: home-assistant-oura
+      metrics_path: /api/prometheus
+      bearer_token_file: /etc/vm/secrets/home-assistant-token/token
+      static_configs:
+        - targets:
+            - home-assistant-app.home.svc.cluster.local:8123
+      metric_relabel_configs:
+        # HA exports ~13k series; keep only the Oura sleep entities, then only the
+        # value families (dropping hass_entity_available / hass_state_change /
+        # hass_last_updated_time_seconds bookkeeping for those same entities).
+        - action: keep
+          source_labels: [entity]
+          regex: sensor\.oura_ring_(total_sleep_duration|deep_sleep_duration|rem_sleep_duration|light_sleep_duration|awake_time|time_in_bed|sleep_latency|sleep_efficiency|average_sleep_heart_rate|lowest_sleep_heart_rate|average_sleep_hrv|sleep_score)
+        - action: keep
+          source_labels: [__name__]
+          regex: hass_sensor_(duration_h|duration_min|unit_percent|unit_bpm|unit_ms|state)
+        # Rewrite onto the same metric names the Apple Health backfill uses, so the
+        # dashboard panels carry straight on from the imported history.
+        - source_labels: [entity]
+          regex: sensor\.oura_ring_total_sleep_duration
+          target_label: __name__
+          replacement: health_sleep_asleep_hours
+        - source_labels: [entity]
+          regex: sensor\.oura_ring_deep_sleep_duration
+          target_label: __name__
+          replacement: health_sleep_deep_hours
+        - source_labels: [entity]
+          regex: sensor\.oura_ring_rem_sleep_duration
+          target_label: __name__
+          replacement: health_sleep_rem_hours
+        # Oura calls it "light", Apple calls the same stage "core".
+        - source_labels: [entity]
+          regex: sensor\.oura_ring_light_sleep_duration
+          target_label: __name__
+          replacement: health_sleep_core_hours
+        - source_labels: [entity]
+          regex: sensor\.oura_ring_awake_time
+          target_label: __name__
+          replacement: health_sleep_awake_hours
+        - source_labels: [entity]
+          regex: sensor\.oura_ring_time_in_bed
+          target_label: __name__
+          replacement: health_sleep_in_bed_hours
+        - source_labels: [entity]
+          regex: sensor\.oura_ring_sleep_latency
+          target_label: __name__
+          replacement: health_sleep_latency_minutes
+        - source_labels: [entity]
+          regex: sensor\.oura_ring_sleep_efficiency
+          target_label: __name__
+          replacement: health_sleep_efficiency_percent
+        - source_labels: [entity]
+          regex: sensor\.oura_ring_average_sleep_heart_rate
+          target_label: __name__
+          replacement: health_sleep_heart_rate_bpm
+        - source_labels: [entity]
+          regex: sensor\.oura_ring_lowest_sleep_heart_rate
+          target_label: __name__
+          replacement: health_sleep_heart_rate_min_bpm
+        # Oura reports rMSSD here while Apple Health reports SDNN — same idea,
+        # different algorithm, hence the source-neutral metric name. Compare within
+        # a source, not across them.
+        - source_labels: [entity]
+          regex: sensor\.oura_ring_average_sleep_hrv
+          target_label: __name__
+          replacement: health_sleep_hrv_ms
+        - source_labels: [entity]
+          regex: sensor\.oura_ring_sleep_score
+          target_label: __name__
+          replacement: health_sleep_score
+        - action: labeldrop
+          regex: (entity|friendly_name|domain|area|job|instance)
+        # Matches the label the importer writes for HealthKit's Oura samples, so
+        # live nights extend the same series instead of forking a new one.
+        - target_label: source
+          replacement: Oura

--- a/kubernetes/apps/monitoring/health-metrics/ks.yaml
+++ b/kubernetes/apps/monitoring/health-metrics/ks.yaml
@@ -14,6 +14,8 @@ spec:
       namespace: monitoring
     - name: rook-ceph-cluster
       namespace: rook-ceph
+    - name: external-secrets-stores
+      namespace: security
   path: ./kubernetes/apps/monitoring/health-metrics/app
   prune: true
   sourceRef:

--- a/scripts/apple-health-sleep-import.py
+++ b/scripts/apple-health-sleep-import.py
@@ -41,7 +41,9 @@ ASLEEP_STAGES = ("core", "deep", "rem", "asleep_unspecified")
 # Nightly quantity types worth carrying alongside the stages.
 QUANTITIES = {
     "HKQuantityTypeIdentifierHeartRate": "heart_rate_bpm",
-    "HKQuantityTypeIdentifierHeartRateVariabilitySDNN": "hrv_sdnn_ms",
+    # Apple reports SDNN, Oura (via the HA feed) reports rMSSD. Same concept,
+    # different algorithm, so the metric name stays source-neutral.
+    "HKQuantityTypeIdentifierHeartRateVariabilitySDNN": "hrv_ms",
     "HKQuantityTypeIdentifierRestingHeartRate": "resting_heart_rate_bpm",
     "HKQuantityTypeIdentifierRespiratoryRate": "respiratory_rate_bpm",
     "HKQuantityTypeIdentifierOxygenSaturation": "oxygen_saturation_percent",
@@ -321,7 +323,7 @@ def build_series(sessions: list[Session], quantities) -> dict[tuple[str, tuple],
         emit("sleep_sessions", source, night, tz, float(len(group)))
 
         for metric in (
-            "heart_rate_bpm", "heart_rate_min_bpm", "hrv_sdnn_ms",
+            "heart_rate_bpm", "heart_rate_min_bpm", "hrv_ms",
             "respiratory_rate_bpm", "oxygen_saturation_percent",
             "wrist_temperature_celsius",
         ):


### PR DESCRIPTION
Follow-up to #3914 / #3916. The backfill was one-shot, so the dashboard froze at 2026-07-30. This wires HA's Prometheus exporter in so ongoing nights extend the **same** series — one dashboard, no second set of panels.

## How it lines up

HA exports the Oura sensors as `hass_sensor_duration_h{entity="sensor.oura_ring_deep_sleep_duration"}` etc. Checked against the backfill for 2026-07-30 and they agree exactly, so relabelling is enough — no seam:

| HA | → | backfill metric |
|---|---|---|
| `oura_ring_total_sleep_duration` 7.2 | → | `health_sleep_asleep_hours` 7.20 |
| `oura_ring_deep_sleep_duration` 2.0667 | → | `health_sleep_deep_hours` 2.07 |
| `oura_ring_light_sleep_duration` 3.108 | → | `health_sleep_core_hours` 3.11 |
| `oura_ring_rem_sleep_duration` 2.025 | → | `health_sleep_rem_hours` 2.02 |
| `oura_ring_time_in_bed` 8.7747 | → | `health_sleep_in_bed_hours` 8.78 |

12 series in total, incl. efficiency, latency, sleep/lowest HR, HRV and sleep score.

## Notes

- **Inline scrape config, not a `VMScrapeConfig` CR.** The k8s-stack vmagent runs `selectAllByDefault: true` and would otherwise scrape it as well, duplicating these series into the 1-month cluster instance under a second identity.
- **Token**: reuses the existing `ha-mcp` 1Password item — `/api/prometheus` accepts that long-lived token. Verified the endpoint is enabled (401 with no auth, while a bogus path gives 404).
- **`avg_over_time` → `last_over_time` for per-night values.** This is a correctness fix, not cosmetics: with a 15m scrape the Oura sensor still holds *the previous night's* value until the ring syncs in the morning, so averaging a noon-to-noon window blends two nights. The last sample before noon is the right one, and for the 1-sample-per-night backfill it's simply that sample.
- **Rolling means use subqueries** — `avg_over_time((<per-night>)[30d:1d])` — so each night counts once no matter how often it was scraped. Same for the night counter, which would otherwise report scrape samples.
- **Stacked stage chart no longer double-counts 2022–2024.** AutoSleep (unstaged) and Apple Watch (staged) both recorded then, so the stack showed a night once as `Asleep (unstaged)` and again as deep+REM+core — legend means were 7.52h unstaged *plus* 5.65+1.41+0.67. The unstaged series is now hidden on nights that have real stages.
- **`health_sleep_hrv_sdnn_ms` → `health_sleep_hrv_ms`.** Apple reports SDNN, Oura reports rMSSD (52ms vs 31ms here). Same concept, different algorithm — the old name was wrong for half the data, and the panel note now says to compare within a source.
- New panels for **sleep score** and **naps**, both of which were already collected but displayed nowhere.

## Test plan

- [x] `kustomize build` + `yamllint` clean; secret mount path `/etc/vm/secrets/<name>/` confirmed against the operator docs
- [x] re-imported after the HRV rename; every panel query returns data
- [x] `unless` verified per era: 2019 night shows unstaged, 2023/2026 nights hide it
- [x] subquery rolling means and night counter verified against real data
- [ ] after merge: VMAgent target healthy, `source="Oura"` series growing, next morning's night appears without a re-export