### PR TITLE
fix(monitoring): correct sleep HRV panel and shorten dashboard resync

### DIFF
--- a/kubernetes/apps/monitoring/grafana-operator/instance/dashboards/sleep-dashboard.json
+++ b/kubernetes/apps/monitoring/grafana-operator/instance/dashboards/sleep-dashboard.json
@@ -1123,12 +1123,12 @@
     {
       "id": 15,
       "type": "timeseries",
-      "title": "HRV (SDNN)",
+      "title": "HRV",
       "datasource": {
         "type": "prometheus",
         "uid": "health-metrics"
       },
-      "description": "",
+      "description": "Apple Health carries no Oura HRV at all \u2014 the Oura app writes sleep stages and heart rate into HealthKit but not HRV, so all 10,680 exported HRV records are Apple Watch (SDNN). Oura HRV (rMSSD) only starts with the live Home Assistant feed on 2026-07-30, one point per night. Note the source label on backfilled HRV names the app that recorded the *sleep session*, not the device that measured HRV \u2014 so AutoSleep- and NapBot-labelled HRV is Apple Watch data too.",
       "interval": "1d",
       "gridPos": {
         "h": 8,

--- a/kubernetes/apps/monitoring/grafana-operator/instance/dashboards/sleep.yaml
+++ b/kubernetes/apps/monitoring/grafana-operator/instance/dashboards/sleep.yaml
@@ -5,6 +5,11 @@ metadata:
   name: sleep
 spec:
   allowCrossNamespaceImport: true
+  # The operator runs --default-resync-period=10m, and for a configMapRef dashboard
+  # nothing re-reads the ConfigMap in between — so a committed dashboard change can
+  # sit invisible in Grafana for up to 10 minutes after Flux applies it. Polling a
+  # local ConfigMap is cheap; 1m keeps edits roughly immediate.
+  resyncPeriod: 1m
   instanceSelector:
     matchLabels:
       dashboards: grafana


### PR DESCRIPTION
The HRV panel is empty right now for **every** source, not just Oura: #3917 renamed `health_sleep_hrv_sdnn_ms` to `health_sleep_hrv_ms`, but grafana-operator runs `--default-resync-period=10m` and nothing re-reads a `configMapRef` dashboard in between, so Grafana is still serving the previous revision querying the removed name. It self-heals on the next resync — this makes that lag stop mattering.

- **`resyncPeriod: 1m`** on the dashboard CR. This lag has now caused two rounds of "the fix is committed but the dashboard still looks broken"; polling a local ConfigMap every minute is cheap.
- **Panel title `HRV (SDNN)` → `HRV`**, which is no longer accurate for half the data.
- **Documented the HRV provenance**, because "no Oura HRV" is a property of the source data, not a bug:
  - Apple Health contains **zero** Oura HRV records — the Oura app writes sleep stages and heart rate into HealthKit but not HRV. All 10,680 exported HRV records are Apple Watch (SDNN).
  - Oura HRV (rMSSD) therefore begins with the live HA feed on 2026-07-30, one point per night from here on.
  - The source label on backfilled HRV names the app that recorded the *sleep session*, not the device that measured HRV — so AutoSleep- and NapBot-labelled HRV is Apple Watch data as well.

## Test plan

- [x] `kustomize build` + `yamllint` clean
- [x] verified against the export: 10,680 HRV records, all `sourceName="Nikola's Apple Watch"`, 0 from Oura
- [x] verified in VictoriaMetrics: `health_sleep_hrv_ms` has 1 Oura sample (today's first scrape) vs 403 Apple Watch / 489 AutoSleep / 13 NapBot
- [ ] after merge: HRV panel populated again, and dashboard edits appear within ~1m