### PR TITLE
fix(monitoring): bucket sleep nights by calendar day, add breathing disturbance index

### DIFF
--- a/kubernetes/apps/monitoring/grafana-operator/instance/dashboards/sleep-dashboard.json
+++ b/kubernetes/apps/monitoring/grafana-operator/instance/dashboards/sleep-dashboard.json
@@ -94,7 +94,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg_over_time((avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -24h)))[30d:1d])",
           "legendFormat": "Asleep (30d avg)",
           "instant": true,
           "range": false,
@@ -155,7 +155,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg_over_time((avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -24h)))[30d:1d])",
           "legendFormat": "Deep (30d avg)",
           "instant": true,
           "range": false,
@@ -216,7 +216,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg_over_time((avg(last_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -24h)))[30d:1d])",
           "legendFormat": "REM (30d avg)",
           "instant": true,
           "range": false,
@@ -277,7 +277,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg_over_time((avg(last_over_time(health_sleep_efficiency_percent{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_efficiency_percent{source=~\"$source\"}[1d] offset -24h)))[30d:1d])",
           "legendFormat": "Efficiency (30d avg)",
           "instant": true,
           "range": false,
@@ -338,7 +338,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg_over_time((avg(last_over_time(health_resting_heart_rate_bpm[1d] offset -12h)))[30d:1d])",
+          "expr": "avg_over_time((avg(last_over_time(health_resting_heart_rate_bpm[1d] offset -24h)))[30d:1d])",
           "legendFormat": "Resting HR (30d avg)",
           "instant": true,
           "range": false,
@@ -399,7 +399,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "count_over_time((avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h)))[$__range:1d])",
+          "expr": "count_over_time((avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -24h)))[$__range:1d])",
           "legendFormat": "Nights in range",
           "instant": true,
           "range": false,
@@ -463,7 +463,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "Deep",
           "instant": false,
           "range": true,
@@ -475,7 +475,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "REM",
           "instant": false,
           "range": true,
@@ -487,7 +487,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_core_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_core_hours{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "Core / light",
           "instant": false,
           "range": true,
@@ -499,7 +499,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_asleep_unspecified_hours{source=~\"$source\"}[1d] offset -12h)) unless avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_asleep_unspecified_hours{source=~\"$source\"}[1d] offset -24h)) unless avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "Asleep (unstaged)",
           "instant": false,
           "range": true,
@@ -511,7 +511,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_awake_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_awake_hours{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "Awake",
           "instant": false,
           "range": true,
@@ -571,7 +571,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "Asleep",
           "instant": false,
           "range": true,
@@ -583,7 +583,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg_over_time((avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h)))[7d:1d])",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -24h)))[7d:1d])",
           "legendFormat": "7-night avg",
           "instant": false,
           "range": true,
@@ -595,7 +595,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg_over_time((avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -24h)))[30d:1d])",
           "legendFormat": "30-night avg",
           "instant": false,
           "range": true,
@@ -607,7 +607,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_in_bed_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_in_bed_hours{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "In bed",
           "instant": false,
           "range": true,
@@ -680,7 +680,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_efficiency_percent{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_efficiency_percent{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "Efficiency %",
           "instant": false,
           "range": true,
@@ -692,7 +692,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg_over_time((avg(last_over_time(health_sleep_efficiency_percent{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_efficiency_percent{source=~\"$source\"}[1d] offset -24h)))[30d:1d])",
           "legendFormat": "Efficiency % (30-night avg)",
           "instant": false,
           "range": true,
@@ -704,7 +704,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_latency_minutes{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_latency_minutes{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "Latency (min)",
           "instant": false,
           "range": true,
@@ -764,7 +764,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "Deep",
           "instant": false,
           "range": true,
@@ -776,7 +776,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg_over_time((avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h)))[7d:1d])",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -24h)))[7d:1d])",
           "legendFormat": "7-night avg",
           "instant": false,
           "range": true,
@@ -788,7 +788,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg_over_time((avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -24h)))[30d:1d])",
           "legendFormat": "30-night avg",
           "instant": false,
           "range": true,
@@ -848,7 +848,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "REM",
           "instant": false,
           "range": true,
@@ -860,7 +860,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg_over_time((avg(last_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -12h)))[7d:1d])",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -24h)))[7d:1d])",
           "legendFormat": "7-night avg",
           "instant": false,
           "range": true,
@@ -872,7 +872,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg_over_time((avg(last_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -24h)))[30d:1d])",
           "legendFormat": "30-night avg",
           "instant": false,
           "range": true,
@@ -932,7 +932,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "100 * avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -12h)) / avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "100 * avg(last_over_time(health_sleep_deep_hours{source=~\"$source\"}[1d] offset -24h)) / avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "Deep %",
           "instant": false,
           "range": true,
@@ -944,7 +944,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "100 * avg(last_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -12h)) / avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "100 * avg(last_over_time(health_sleep_rem_hours{source=~\"$source\"}[1d] offset -24h)) / avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "REM %",
           "instant": false,
           "range": true,
@@ -956,7 +956,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "100 * avg(last_over_time(health_sleep_core_hours{source=~\"$source\"}[1d] offset -12h)) / avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "100 * avg(last_over_time(health_sleep_core_hours{source=~\"$source\"}[1d] offset -24h)) / avg(last_over_time(health_sleep_asleep_hours{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "Core %",
           "instant": false,
           "range": true,
@@ -1016,7 +1016,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_bedtime_offset_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_bedtime_offset_hours{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "Bedtime (h from midnight)",
           "instant": false,
           "range": true,
@@ -1028,7 +1028,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_waketime_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_waketime_hours{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "Wake time (h after midnight)",
           "instant": false,
           "range": true,
@@ -1088,7 +1088,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_heart_rate_bpm{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_heart_rate_bpm{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "Mean during sleep",
           "instant": false,
           "range": true,
@@ -1100,7 +1100,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_heart_rate_min_bpm{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_heart_rate_min_bpm{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "Lowest during sleep",
           "instant": false,
           "range": true,
@@ -1112,7 +1112,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_resting_heart_rate_bpm[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_resting_heart_rate_bpm[1d] offset -24h))",
           "legendFormat": "Resting (daily)",
           "instant": false,
           "range": true,
@@ -1172,7 +1172,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_hrv_ms{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_hrv_ms{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "HRV",
           "instant": false,
           "range": true,
@@ -1184,7 +1184,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg_over_time((avg(last_over_time(health_sleep_hrv_ms{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_hrv_ms{source=~\"$source\"}[1d] offset -24h)))[30d:1d])",
           "legendFormat": "30-night avg",
           "instant": false,
           "range": true,
@@ -1195,12 +1195,12 @@
     {
       "id": 16,
       "type": "timeseries",
-      "title": "Respiration & blood oxygen",
+      "title": "Respiration, SpO2 & disturbance",
       "datasource": {
         "type": "prometheus",
         "uid": "health-metrics"
       },
-      "description": "",
+      "description": "Respiratory rate and SpO2 come from the Apple Health backfill; the breathing disturbance index is Oura-only and live from the Home Assistant feed, so it has no history before 2026-07-30.",
       "interval": "1d",
       "gridPos": {
         "h": 8,
@@ -1244,7 +1244,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_respiratory_rate_bpm{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_respiratory_rate_bpm{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "Respiratory rate (/min)",
           "instant": false,
           "range": true,
@@ -1256,8 +1256,20 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_oxygen_saturation_percent{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_oxygen_saturation_percent{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "SpO2 %",
+          "instant": false,
+          "range": true,
+          "editorMode": "code"
+        },
+        {
+          "refId": "C",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "health-metrics"
+          },
+          "expr": "avg(last_over_time(health_sleep_breathing_disturbance_index{source=~\"$source\"}[1d] offset -24h))",
+          "legendFormat": "Breathing disturbance index",
           "instant": false,
           "range": true,
           "editorMode": "code"
@@ -1316,7 +1328,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_wrist_temperature_celsius{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_wrist_temperature_celsius{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "Wrist temp",
           "instant": false,
           "range": true,
@@ -1376,7 +1388,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_score{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_score{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "Score",
           "instant": false,
           "range": true,
@@ -1388,7 +1400,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg_over_time((avg(last_over_time(health_sleep_score{source=~\"$source\"}[1d] offset -12h)))[30d:1d])",
+          "expr": "avg_over_time((avg(last_over_time(health_sleep_score{source=~\"$source\"}[1d] offset -24h)))[30d:1d])",
           "legendFormat": "30-night avg",
           "instant": false,
           "range": true,
@@ -1448,7 +1460,7 @@
             "type": "prometheus",
             "uid": "health-metrics"
           },
-          "expr": "avg(last_over_time(health_sleep_nap_hours{source=~\"$source\"}[1d] offset -12h))",
+          "expr": "avg(last_over_time(health_sleep_nap_hours{source=~\"$source\"}[1d] offset -24h))",
           "legendFormat": "Nap time",
           "instant": false,
           "range": true,
@@ -1472,7 +1484,7 @@
       },
       "options": {
         "mode": "markdown",
-        "content": "Backfilled from an Apple Health **Export All Health Data** archive into the `vmsingle-health` instance (100y retention) \u2014 see `kubernetes/apps/monitoring/health-metrics`.\n\n- **Nights** run noon-to-noon and are labelled with the **wake-up date**, matching the Health app.\n- Each night uses its **longest sleep session**; extra sessions are counted separately as `health_sleep_nap_hours`.\n- **Stage data (deep/REM/core) only exists from 2022 onward** \u2014 earlier nights came from AutoSleep, which writes undifferentiated `asleep`, and Apple Watch staging needs watchOS 9. Pre-2022 nights therefore appear in the stacked chart as *Asleep (unstaged)*.\n- Sources overlap in time (AutoSleep 2019-2024, Apple Watch 2020-2026, Oura 2026-). Use the **Source** picker to compare one against another; with several selected, values are averaged.\n- Oura writes some nights twice ~29s apart; the importer flattens overlapping segments so stage totals can never exceed the session length.\n- **Ongoing nights arrive live** from Home Assistant's Prometheus exporter (`sensor.oura_ring_*`, scraped every 15m and relabelled onto these same metric names), so the dashboard keeps moving without another export.\n- **HRV is not comparable across sources**: Apple Health reports SDNN, Oura reports rMSSD. Pick a single source before reading trends off that panel."
+        "content": "Backfilled from an Apple Health **Export All Health Data** archive into the `vmsingle-health` instance (100y retention) \u2014 see `kubernetes/apps/monitoring/health-metrics`.\n\n- **Nights** are labelled with the **wake-up date**, matching the Health app. Sessions are assigned noon-to-noon on import; panels then bucket each night on that date's calendar day, so live samples arriving through the day land on their own night.\n- Each night uses its **longest sleep session**; extra sessions are counted separately as `health_sleep_nap_hours`.\n- **Stage data (deep/REM/core) only exists from 2022 onward** \u2014 earlier nights came from AutoSleep, which writes undifferentiated `asleep`, and Apple Watch staging needs watchOS 9. Pre-2022 nights therefore appear in the stacked chart as *Asleep (unstaged)*.\n- Sources overlap in time (AutoSleep 2019-2024, Apple Watch 2020-2026, Oura 2026-). Use the **Source** picker to compare one against another; with several selected, values are averaged.\n- Oura writes some nights twice ~29s apart; the importer flattens overlapping segments so stage totals can never exceed the session length.\n- **Ongoing nights arrive live** from Home Assistant's Prometheus exporter (`sensor.oura_ring_*`, scraped every 15m and relabelled onto these same metric names), so the dashboard keeps moving without another export.\n- **Sleep score and breathing disturbance index are Oura-only and live-only.** Apple Health has no equivalent of either, so neither has history before the feed went in on 2026-07-30.\n- **HRV is not comparable across sources**: Apple Health reports SDNN, Oura reports rMSSD. Pick a single source before reading trends off that panel."
       }
     }
   ]

--- a/kubernetes/apps/monitoring/health-metrics/app/vmagent.yaml
+++ b/kubernetes/apps/monitoring/health-metrics/app/vmagent.yaml
@@ -35,7 +35,7 @@ spec:
         # hass_last_updated_time_seconds bookkeeping for those same entities).
         - action: keep
           source_labels: [entity]
-          regex: sensor\.oura_ring_(total_sleep_duration|deep_sleep_duration|rem_sleep_duration|light_sleep_duration|awake_time|time_in_bed|sleep_latency|sleep_efficiency|average_sleep_heart_rate|lowest_sleep_heart_rate|average_sleep_hrv|sleep_score)
+          regex: sensor\.oura_ring_(total_sleep_duration|deep_sleep_duration|rem_sleep_duration|light_sleep_duration|awake_time|time_in_bed|sleep_latency|sleep_efficiency|average_sleep_heart_rate|lowest_sleep_heart_rate|average_sleep_hrv|sleep_score|breathing_disturbance_index)
         - action: keep
           source_labels: [__name__]
           regex: hass_sensor_(duration_h|duration_min|unit_percent|unit_bpm|unit_ms|state)
@@ -93,6 +93,11 @@ spec:
           regex: sensor\.oura_ring_sleep_score
           target_label: __name__
           replacement: health_sleep_score
+        # Oura-only; Apple Health has no equivalent, so this has no backfilled history.
+        - source_labels: [entity]
+          regex: sensor\.oura_ring_breathing_disturbance_index
+          target_label: __name__
+          replacement: health_sleep_breathing_disturbance_index
         - action: labeldrop
           regex: (entity|friendly_name|domain|area|job|instance)
         # Matches the label the importer writes for HealthKit's Oura samples, so


### PR DESCRIPTION
## Why sleep score showed "No data"

Two reasons, and one of them is a bug of mine.

**The bug.** Panels bucketed each night into a **noon-to-noon** window (`offset -12h`). That fits the backfill, whose single sample per night sits at local noon — but not the live HA feed, whose samples arrive throughout the day. Anything scraped after noon fell into the *next* night's bucket, so a night's own live data was invisible until the following day. Today's values were stored the whole time:

| bucket 2026-07-30 | `offset -12h` (old) | `offset -24h` (new) |
|---|---|---|
| `health_sleep_asleep_hours` | 7.2 | 7.2 |
| `health_sleep_score` | **EMPTY** | **82** |
| `health_sleep_hrv_ms` | **EMPTY** | **31** |

Windowing on the wake date's **calendar day** catches both shapes: the backfill's local-noon sample and every live sample from that day. The last sample in the day is always the settled one, since Oura won't publish the next night before midnight.

**The data reason.** Apple Health has no concept of a sleep score, so there is no history to backfill — the score only exists from the live feed (2026-07-30 onward). On a 7-day view that was the *only* thing those panels could have drawn, which is why the window bug hid them completely while the 5-year view still showed Apple Watch HRV.

## Breathing disturbance index

Added `sensor.oura_ring_breathing_disturbance_index` → `health_sleep_breathing_disturbance_index`, plotted next to respiratory rate and SpO2. Oura-only, no Apple Health equivalent, so same deal: starts today, not 2019.

## Test plan

- [x] historical parity confirmed on 2019-04-21, 2022-11-05, 2023-09-15, 2026-06-30 — identical under both offsets
- [x] `unless` (unstaged-vs-staged) still correct under the new window: empty on the staged 2023 night, 6.18 on the 2019 unstaged night
- [x] all 41 panel queries migrated; zero `offset -12h` left
- [x] `kustomize build` + `yamllint` clean
- [ ] after merge: score / HRV / BDI visible on a 7-day view, one point per night from here

## Heads-up on the 7-day view

Even after this, `Sleeping wrist temperature` and `Naps` will look sparse: the export only holds 11 wrist-temperature samples total (Series 8+ feature, none in the last week), and naps only exist on nights with a second sleep session.