### PR TITLE
fix(monitoring): drop the injected prometheus external label so sleep metrics are one series

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ wiki
 # Claude Code
 .claude/settings.json
 .claude/settings.local.json
+oura-models-enc/

--- a/kubernetes/apps/monitoring/health-metrics/app/vmagent.yaml
+++ b/kubernetes/apps/monitoring/health-metrics/app/vmagent.yaml
@@ -12,6 +12,14 @@ spec:
   # Oura publishes one set of values per night, a few minutes after the ring syncs
   # in the morning. Scraping often would only restate the same numbers.
   scrapeInterval: 15m
+  # The operator otherwise injects `prometheus: monitoring/health` as a global
+  # external label, which forks every metric into two series — one from the
+  # importers (no such label) and one from this agent — for the nights both cover.
+  # Panel queries aggregate with avg() so the displayed values stayed correct, but
+  # the series identity did not match, which was the whole point of relabelling
+  # onto the imported metric names. An empty value drops the label.
+  externalLabels:
+    prometheus: ""
   secrets:
     - home-assistant-token
   remoteWrite:


### PR DESCRIPTION
Verifying the backfill re-run turned up a claim from #3917 that wasn't actually true: history and live data were **not** sharing a series.

The operator injects `prometheus: monitoring/health` as a global external label into the VMAgent scrape config, so every metric exists twice for nights both paths cover:

```
{__name__="health_sleep_score", source="Oura", prometheus="monitoring/health"}   <- live feed
{__name__="health_sleep_score", source="Oura"}                                  <- importers
```

Displayed values were never wrong — every panel query aggregates with `avg()` and both series carry the same number — but relabelling the live feed onto the imported metric names is pointless if the label sets still differ, and it doubles the series count for the overlap. An empty external-label value drops the label, so the live feed writes into the imported series identity.

No data loss and nothing needs re-importing. The pre-existing duplicate series stops receiving samples once this lands, and I'll delete its ~50 samples from today afterwards so a single identity remains.

## Test plan

- [x] `kustomize build` + `yamllint` clean
- [ ] after merge: generated config's `global.external_labels` no longer carries `prometheus`, `/api/v1/series` returns one series per metric, and the next scrape lands on it
