### PR TITLE
feat(home): add petkit-local

### DIFF
--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -16,5 +16,6 @@ resources:
   - ./wyoming-onnx-asr/ks.yaml
   - ./scrypted/ks.yaml
   - ./mosquitto/ks.yaml
+  - ./petkit-local/ks.yaml
   - ./appdaemon/ks.yaml
   - ./asterisk/ks.yaml

--- a/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
+++ b/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
@@ -1,0 +1,108 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app petkit-local
+  namespace: home
+spec:
+  interval: 5m
+  chartRef:
+    kind: OCIRepository
+    name: petkit-local
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      petkit-local:
+        containers:
+          app:
+            image:
+              repository: quay.io/nklmilojevic/petkit-local
+              tag: 1.1.0
+            args:
+              # The device is handed only the api-url host for MQTT and media
+              # uploads, on firmware-fixed ports (443/9000) — so this must stay
+              # the LoadBalancer IP, and the MQTT TLS listener is remapped from
+              # 443 by the Service so the pod never binds a privileged port.
+              - --data-dir=/data
+              - --port=8080
+              - --api-url=http://10.40.0.33/6/
+              - --mqtt-tls
+              - --mqtt-tls-port=8443
+              - --ha-mqtt-host=mosquitto.home.svc.cluster.local
+              - --ha-mqtt-port=1883
+            env:
+              TZ: "Europe/Belgrade"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &panel-port 8099
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+    service:
+      app:
+        controller: petkit-local
+        type: LoadBalancer
+        annotations:
+          lbipam.cilium.io/ips: "10.40.0.33"
+        ports:
+          http:
+            port: 80
+            targetPort: 8080
+          mqtts:
+            port: 443
+            targetPort: 8443
+          media:
+            port: 9000
+          panel:
+            port: *panel-port
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.nikola.wtf"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *panel-port
+    persistence:
+      config:
+        existingClaim: petkit-local-config
+        globalMounts:
+          - path: /data
+      media:
+        type: emptyDir
+        globalMounts:
+          - path: /media/petkit
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/home/petkit-local/app/kustomization.yaml
+++ b/kubernetes/apps/home/petkit-local/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/home/petkit-local/app/ocirepository.yaml
+++ b/kubernetes/apps/home/petkit-local/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: petkit-local
+  namespace: home
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/home/petkit-local/ks.yaml
+++ b/kubernetes/apps/home/petkit-local/ks.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app petkit-local
+spec:
+  components:
+    - ../../../../components/volsync
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: security
+    - name: external-secrets-stores
+      namespace: security
+  path: ./kubernetes/apps/home/petkit-local/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CLAIM: petkit-local-config
+      VOLSYNC_CAPACITY: 2Gi
+      APP_UID: "1000"
+      APP_GID: "1000"


### PR DESCRIPTION
## Description

Deploys [petkit-local](https://github.com/alex-so-3/petkit-local) — a local stand-in for PetKit's cloud — so the Pura Max litter box can be cut off from PetKit's servers and run fully locally, publishing entities to HA over MQTT discovery.

Image is built in [nklmilojevic/containers#432](https://github.com/nklmilojevic/containers/pull/432) (merge + make the quay repo public first).

## Wiring

- **LoadBalancer `10.40.0.33`** — the address the device gets provisioned with. The firmware derives MQTT (443) and media upload (9000) endpoints from the api-url *host* on fixed ports, so the Service maps `80→8080` (device API) and `443→8443` (MQTT TLS listener; pod never binds a privileged port), plus `9000` for media.
- **HA discovery** via `mosquitto.home.svc` (anonymous, same as z2m).
- **Web panel** at `petkit-local.nikola.wtf` via the internal gateway (port 8099).
- **Persistence**: volsync-backed `petkit-local-config` (2Gi) at `/data` — device registry, event DB, broker cert; emptyDir for `/media/petkit` (Pura Max has no camera) and `/tmp`.

## Rollout order

1. Merge the containers PR, wait for CI, make the `quay.io/nklmilojevic/petkit-local` repo public.
2. Merge this.
3. Re-provision the litter box from the panel's Provision tab (Chrome/Edge, Web Bluetooth) → point it at `http://10.40.0.33/6/`, TZ Europe/Belgrade. Reversible by re-provisioning back to PetKit.

Nothing touches the existing cloud integration until step 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)