### PR TITLE
feat(petkit-local): expose RTSP and persist camera media

### DIFF
--- a/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
+++ b/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
@@ -79,6 +79,8 @@ spec:
             targetPort: 8443
           media:
             port: 9000
+          rtsp:
+            port: 8554
           panel:
             port: *panel-port
     route:
@@ -99,7 +101,7 @@ spec:
         globalMounts:
           - path: /data
       media:
-        type: emptyDir
+        existingClaim: petkit-local-media
         globalMounts:
           - path: /media/petkit
       tmp:

--- a/kubernetes/apps/home/petkit-local/app/kustomization.yaml
+++ b/kubernetes/apps/home/petkit-local/app/kustomization.yaml
@@ -5,3 +5,4 @@ namespace: home
 resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/home/petkit-local/app/pvc.yaml
+++ b/kubernetes/apps/home/petkit-local/app/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: petkit-local-media
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: ceph-block


### PR DESCRIPTION
## Description

Camera-device readiness for the YumShare Solo (D4H):

- Expose go2rtc's RTSP port (8554, hardcoded upstream) on the LoadBalancer so HA can consume the patched camera stream.
- Move `/media/petkit` from emptyDir to a 20Gi ceph-block PVC (`petkit-local-media`) so uploaded clips/snapshots survive pod restarts. Upstream's retention sweeper manages growth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)