### PR TITLE
feat(home): re-add petkit-local at 1.6.0

### DIFF
--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -16,5 +16,6 @@ resources:
   - ./wyoming-onnx-asr/ks.yaml
   - ./scrypted/ks.yaml
   - ./mosquitto/ks.yaml
+  - ./petkit-local/ks.yaml
   - ./appdaemon/ks.yaml
   - ./asterisk/ks.yaml

--- a/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
+++ b/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
@@ -1,0 +1,110 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app petkit-local
+  namespace: home
+spec:
+  interval: 5m
+  chartRef:
+    kind: OCIRepository
+    name: petkit-local
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      petkit-local:
+        containers:
+          app:
+            image:
+              repository: quay.io/nklmilojevic/petkit-local
+              tag: 1.6.0
+            args:
+              # The device is handed only the api-url host for MQTT and media
+              # uploads, on firmware-fixed ports (443/9000) — so this must stay
+              # the LoadBalancer IP, and the MQTT TLS listener is remapped from
+              # 443 by the Service so the pod never binds a privileged port.
+              - --data-dir=/data
+              - --port=8080
+              - --api-url=http://10.40.0.33/6/
+              - --mqtt-tls
+              - --mqtt-tls-port=8443
+              - --ha-mqtt-host=mosquitto.home.svc.cluster.local
+              - --ha-mqtt-port=1883
+            env:
+              TZ: "Europe/Belgrade"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &panel-port 8099
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+    service:
+      app:
+        controller: petkit-local
+        type: LoadBalancer
+        annotations:
+          lbipam.cilium.io/ips: "10.40.0.33"
+        ports:
+          http:
+            port: 80
+            targetPort: 8080
+          mqtts:
+            port: 443
+            targetPort: 8443
+          media:
+            port: 9000
+          rtsp:
+            port: 8554
+          panel:
+            port: *panel-port
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.nikola.wtf"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *panel-port
+    persistence:
+      config:
+        existingClaim: petkit-local-config
+        globalMounts:
+          - path: /data
+      media:
+        existingClaim: petkit-local-media
+        globalMounts:
+          - path: /media/petkit
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/home/petkit-local/app/kustomization.yaml
+++ b/kubernetes/apps/home/petkit-local/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/home/petkit-local/app/ocirepository.yaml
+++ b/kubernetes/apps/home/petkit-local/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: petkit-local
+  namespace: home
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/home/petkit-local/app/pvc.yaml
+++ b/kubernetes/apps/home/petkit-local/app/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: petkit-local-media
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: ceph-block

--- a/kubernetes/apps/home/petkit-local/ks.yaml
+++ b/kubernetes/apps/home/petkit-local/ks.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app petkit-local
+spec:
+  components:
+    - ../../../../components/volsync
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: security
+    - name: external-secrets-stores
+      namespace: security
+  path: ./kubernetes/apps/home/petkit-local/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CLAIM: petkit-local-config
+      VOLSYNC_CAPACITY: 2Gi
+      APP_UID: "1000"
+      APP_GID: "1000"


### PR DESCRIPTION
Reverts the removal in #3936 and bumps the image to 1.6.0 (containers#439 builds it).

Same shape as the first trial — nothing changed but the tag:
- LB `10.40.0.33` (still unclaimed in the repo; .30/.31/.32 are vector + asterisk)
- ports 80→8080 (device API), 443→8443 (device MQTT TLS), 9000 (media bucket), 8554 (RTSP), 8099 (panel via `petkit-local.nikola.wtf`)
- `petkit-local-config` (volsync, 2Gi) + `petkit-local-media` (20Gi ceph-block); both were pruned on removal, so they come back empty

Upstream 1.2.0 → 1.6.0 fixes BLE provisioning (service lookup by name), tells an HTTP provisioning page it needs HTTPS, patches MQTT/cloud/SSH on ARM devices, and corrects the BLE write frame length that made every fountain command a no-op. Every CLI flag used here still exists in 1.6.0.

Merge **after** containers#439 has published `quay.io/nklmilojevic/petkit-local:1.6.0`.

**Not in this PR:** the UniFi "Allow IoT to PetKit Local" firewall rule (IoT → 10.40.0.33) was deleted at cleanup and has to be recreated before any device can reach the LB.