### PR TITLE
fix(ai): right-size llmkube inference memory requests

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-embedding-0.6b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-embedding-0.6b.yaml
@@ -57,7 +57,9 @@ spec:
     type: ClusterIP
   resources:
     cpu: 100m
-    memory: 6Gi
+    # RSS peaks at 2408Mi; the rest of the working set is mmap'd model pages
+    # and iGPU host buffers, which the kernel reclaims under pressure.
+    memory: 3Gi
   probeOverrides:
     startup:
       httpGet:

--- a/kubernetes/apps/ai/llmkube/models/qwen3-reranker-0.6b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-reranker-0.6b.yaml
@@ -57,7 +57,9 @@ spec:
     type: ClusterIP
   resources:
     cpu: 100m
-    memory: 4Gi
+    # RSS sits at 109Mi flat; the multi-GiB working set is mmap'd model pages
+    # and iGPU host buffers, which the kernel reclaims under pressure.
+    memory: 1Gi
   probeOverrides:
     startup:
       httpGet:


### PR DESCRIPTION
Clears `KubeMemoryOvercommit`, which started firing after petkit-local landed (+77.23MB over the tolerate-one-node-failure budget; the 24h low was only −57MB, so the cluster was already sitting on that line).

The two qwen3 0.6B services requested **10Gi between them** — 17% of the cluster's entire memory-request budget for two 600M-parameter models.

Those requests were sized from working set, which is the wrong signal here. Both run `--mmap`, so the GGUF's pages and the iGPU's shared host buffers land in page cache and get counted in working set even though the kernel reclaims them under pressure:

| pod | request | RSS (7d peak) | page cache | working set |
|---|---|---|---|---|
| qwen3-reranker-0.6b | 4Gi | **109Mi** (flat) | 2526Mi | 5267Mi |
| qwen3-embedding-0.6b | 6Gi | **2408Mi** | 3644Mi | 12116Mi |

- reranker `4Gi` → `1Gi` (≈9x its flat RSS)
- embedding `3Gi` ← `6Gi` (≈25% over its RSS peak)

Neither InferenceService sets a memory *limit* and llmkube only propagates this into requests, so this changes scheduling only — not what either process may allocate. Frees **6Gi** of requests; overcommit goes from +77MB to roughly −6Gi.

Considered and rejected: scaling the reranker to zero when idle. `MEMINI_RERANK_TIMEOUT` is 8s and memini reranks synchronously on every memory search, while a cold start is pod scheduling + init containers + a 3.2s model load — the first search after idle would fail. Also rejected: trimming rook-ceph mgr/OSD or stirling-pdf, whose 7d peaks (8.2Gi / 3.3Gi / 2.4Gi) genuinely exceed their requests.