### PR TITLE
fix(home): pin petkit-local to D4H BLE-fix image digest

### DIFF
--- a/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
+++ b/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
@@ -24,7 +24,11 @@ spec:
           app:
             image:
               repository: quay.io/nklmilojevic/petkit-local
-              tag: 1.6.0
+              # Pinned to the digest of the 1.6.0 build carrying the D4H BLE
+              # provisioning fix (containers#440). The overlay mutates the 1.6.0
+              # tag in place, so the digest is what forces a re-pull. Drop the
+              # digest (back to a plain tag) once the fix is upstream.
+              tag: 1.6.0@sha256:8175ba07b98591528dd10c300e81d409b4de9a2e384f0766c8b29a9891b80c66
             args:
               # The device is handed only the api-url host for MQTT and media
               # uploads, on firmware-fixed ports (443/9000) — so this must stay


### PR DESCRIPTION
Follow-up to [containers#440](https://github.com/nklmilojevic/containers/pull/440), which overlays a patched `app.js` fixing Ingenic (T5/T6/T7/**D4H**/D4SH) Bluetooth provisioning — those devices need the framed `FA FC FD 46` envelope, not the bare JSON upstream 1.6.0 sends.

The overlay **mutates the `1.6.0` tag in place**, so `imagePullPolicy: IfNotPresent` keeps serving the cached, unpatched image (confirmed: a rollout restart came up on the old digest `16c2d465…`). Pinning the new digest `8175ba07…` forces the re-pull.

Revert to a plain `tag:` once the fix lands upstream and the overlay is dropped.

After merge: Flux reconciles → pod rolls onto the patched image → re-provision the D4H in pairing mode from Chrome on `petkit-local.nikola.wtf`.