### PR TITLE
fix(rook-ceph): cap mgr recent-log ring to stop 33h OOM cycle

### DIFF
--- a/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
+++ b/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
@@ -24,7 +24,11 @@ spec:
           app:
             image:
               repository: quay.io/nklmilojevic/petkit-local
-              tag: 1.6.0
+              # Pinned to the digest of the 1.6.0 build carrying the D4H BLE
+              # provisioning fix (containers#440). The overlay mutates the 1.6.0
+              # tag in place, so the digest is what forces a re-pull. Drop the
+              # digest (back to a plain tag) once the fix is upstream.
+              tag: 1.6.0@sha256:8175ba07b98591528dd10c300e81d409b4de9a2e384f0766c8b29a9891b80c66
             args:
               # The device is handed only the api-url host for MQTT and media
               # uploads, on firmware-fixed ports (443/9000) — so this must stay

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -50,6 +50,12 @@ spec:
           device_failure_prediction_mode: local # requires mgr module
         mgr:
           mgr/crash/warn_recent_interval: "7200" # 2h
+          # The active mgr logs the rook module's 15s PodList poll in full at
+          # DEBUG (~583KB/line, prio 0 — no log-level knob suppresses it, see
+          # mgr_module.py MgrRootHandler). At the 10000-entry default, the
+          # in-memory recent-events ring retains those lines and the mgr walks
+          # into its 4Gi limit every ~33h, gets OOM-killed and fails over.
+          log_max_recent: "200" # quote
       cleanupPolicy:
         wipeDevicesFromOtherClusters: true
       crashCollector:


### PR DESCRIPTION
## The active mgr is OOM-killed every ~33 hours

Not a metrics artifact — `container_memory_rss` for the mgr container climbs **linearly at ~115MB/h** from ~220Mi to the 4Gi limit, exits 137, fails over, and starts again. Kills at 07-28 06:30Z, 07-28 20:30Z, 07-30 17:30Z, 07-31 18:00Z, **08-02 22:18Z** (`lastState.terminated.reason: OOMKilled`). The standby mgr sits flat at ~155Mi, so it tracks whoever holds the active role.

```
07-31 18:00Z  →  ~220Mi   (post-kill)
08-02 12:00Z  →  3550Mi
08-02 22:18Z  →  4053Mi   OOMKilled, exit 137
```

## Why

The leak rate *is* the log-flood byte rate:

- The rook mgr module polls `list_namespaced_pod` on the rook-ceph namespace every 15s (`rook_cluster.py` `KubernetesResource`).
- python-kubernetes `client/rest.py:232` logs the whole response unconditionally at DEBUG: `logger.debug("response body: %s", r.data)` — **583,726 bytes per line, 4/min, 3.36GB/day, 99.2% of all mgr log bytes** (measured: 19.85MB of a 20MB tail sits in 34 lines).
- Those records land at ceph prio 0 and **no log-level knob gates them**: `mgr_module.py` attaches `MgrRootHandler` to the python *root* logger and does `root.setLevel(logging.NOTSET)`, while `_set_log_level()` only ever raises `_mgr_log_handler` and `_file_log_handler`. The root handler keeps level 0 forever — which is why `debug_mgr` and `mgr/rook/log_level` (set to `info` on this cluster) provably have no effect.
- With `log_max_recent` at its **10000** default, the in-memory recent-events ring retains those 583KB lines. 10000 × 583KB is 5.8GB, so the container reaches its 4Gi limit long before the ring fills.

v20.2.2 is the newest Tentacle on quay (`v20.2.2-20260616`), so there is no version to upgrade into.

## This change

`log_max_recent: "200"` for the mgr — bounds the ring at ~117MB worst case and ends the OOM cycle. Costs crash-time forensics depth (200 recent events instead of 10000), which is the right trade against a fortnightly-to-daily OOM.

## What it does not fix

The flood itself: still 3.36GB/day written to `/var/log/ceph` on the active mgr's node (currently 727MB retained there, daily rotation, `maxLogSize: 500M`). Two follow-ups, neither in this PR:

1. **Drop the `rook` mgr module** from `cephClusterSpec.mgr.modules` — kills the poll and the flood at source. Costs `ceph orch` (`orch ls`/`ps`/`device ls`) and the dashboard's Hosts/Services pages. The Rook operator itself does not use it.
2. **Upstream tracker** for the `MgrRootHandler` level never being set — a one-line fix in `_set_log_level`.

The vector aggregator filter added in 4382cf299 already keeps these lines out of VictoriaLogs; it does nothing about the mgr's own memory or disk.