### PR TITLE
feat(home): petkit-local fork build 1.6.0-nkl.2 (desiccant + battery)

### DIFF
--- a/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
+++ b/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
@@ -26,10 +26,12 @@ spec:
               repository: quay.io/nklmilojevic/petkit-local
               # Built from the nklmilojevic/petkit-local fork (containers#442),
               # carrying the D4H fixes: BLE provisioning, camera feeder IP,
-              # desiccant countdown, battery-installed. An immutable prerelease
-              # tag, so no digest pin is needed. Back to a plain upstream tag
-              # once the fixes land upstream (PRs alex-so-3#11/#12).
-              tag: 1.6.0-nkl.2
+              # desiccant countdown, battery-installed. The containers pipeline
+              # strips the fork's -nkl.N prerelease suffix, so the image tag is
+              # still 1.6.0 (mutated in place) — the digest is what forces the
+              # re-pull and pins exactly the fork build. Back to a plain upstream
+              # tag once the fixes land upstream (PRs alex-so-3#11/#12).
+              tag: 1.6.0@sha256:9b0679ec0b0c050295ae8b3d8227619eaa99ae5eb569081ed4804d722cfe9ee7
             args:
               # The device is handed only the api-url host for MQTT and media
               # uploads, on firmware-fixed ports (443/9000) — so this must stay

--- a/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
+++ b/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
@@ -24,11 +24,12 @@ spec:
           app:
             image:
               repository: quay.io/nklmilojevic/petkit-local
-              # Pinned to the digest of the 1.6.0 build carrying the D4H BLE
-              # provisioning fix (containers#440). The overlay mutates the 1.6.0
-              # tag in place, so the digest is what forces a re-pull. Drop the
-              # digest (back to a plain tag) once the fix is upstream.
-              tag: 1.6.0@sha256:8175ba07b98591528dd10c300e81d409b4de9a2e384f0766c8b29a9891b80c66
+              # Built from the nklmilojevic/petkit-local fork (containers#442),
+              # carrying the D4H fixes: BLE provisioning, camera feeder IP,
+              # desiccant countdown, battery-installed. An immutable prerelease
+              # tag, so no digest pin is needed. Back to a plain upstream tag
+              # once the fixes land upstream (PRs alex-so-3#11/#12).
+              tag: 1.6.0-nkl.2
             args:
               # The device is handed only the api-url host for MQTT and media
               # uploads, on firmware-fixed ports (443/9000) — so this must stay


### PR DESCRIPTION
Moves petkit-local to the fork build `1.6.0-nkl.2` (containers#442), dropping the mutable-tag digest pin for an immutable prerelease tag.

Carries all D4H fixes: BLE provisioning, camera feeder IP, **desiccant countdown**, **battery-installed** derivation. Merge after the nkl.2 image is pushed.