### PR TITLE
feat(home): onvif-server — bridge D4H camera into UniFi Protect

### DIFF
--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -17,5 +17,6 @@ resources:
   - ./scrypted/ks.yaml
   - ./mosquitto/ks.yaml
   - ./petkit-local/ks.yaml
+  - ./onvif-server/ks.yaml
   - ./appdaemon/ks.yaml
   - ./asterisk/ks.yaml

--- a/kubernetes/apps/home/onvif-server/app/configmap.yaml
+++ b/kubernetes/apps/home/onvif-server/app/configmap.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: onvif-server-config
+  namespace: home
+data:
+  # Virtual ONVIF device that wraps petkit-local's go2rtc RTSP stream so UniFi
+  # Protect (Settings -> System -> Discover Third-Party Cameras) can adopt the
+  # YumShare Solo (D4H) natively. `mac` MUST match the multus macvlan MAC in the
+  # HelmRelease pod annotation — the server binds to the interface with that MAC.
+  # RTSP is proxied on the server's own :8554; the upstream pull to 10.40.0.33
+  # rides the pod's cluster interface, so no cross-VLAN firewall rule is needed.
+  onvif.yaml: |
+    onvif:
+      - mac: a2:07:20:03:00:07
+        ports:
+          server: 8081
+          rtsp: 8554
+          snapshot: 8580
+        name: YumShare Solo
+        uuid: a1b2c3d4-0088-4100-8000-000300008810
+        highQuality:
+          rtsp: /300008810
+          snapshot: /300008810
+          width: 1920
+          height: 1080
+          framerate: 15
+          bitrate: 2048
+          quality: 4
+        lowQuality:
+          rtsp: /300008810
+          snapshot: /300008810
+          width: 640
+          height: 360
+          framerate: 15
+          bitrate: 512
+          quality: 1
+        target:
+          hostname: 10.40.0.33
+          ports:
+            rtsp: 8554
+            snapshot: 8554

--- a/kubernetes/apps/home/onvif-server/app/helmrelease.yaml
+++ b/kubernetes/apps/home/onvif-server/app/helmrelease.yaml
@@ -1,0 +1,52 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: onvif-server
+  namespace: home
+spec:
+  interval: 5m
+  chartRef:
+    kind: OCIRepository
+    name: onvif-server
+  values:
+    controllers:
+      onvif-server:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          # macvlan on the main LAN (bond0.1 / 10.5.0.0/24) so the virtual ONVIF
+          # camera has its own MAC + IP on the same L2 as the UDM-SE — required
+          # for UniFi Protect's WS-Discovery multicast to find it. The MAC here
+          # MUST equal the `mac` in the onvif config (the server binds the iface
+          # with that MAC). .207 is free; .206 is scrypted, .253 tailscale.
+          annotations:
+            k8s.v1.cni.cncf.io/networks: |
+              [{
+                "name": "multus-host",
+                "namespace": "network",
+                "ips": ["10.5.0.207/24"],
+                "mac": "a2:07:20:03:00:07"
+              }]
+        containers:
+          app:
+            image:
+              repository: ghcr.io/daniela-hase/onvif-server
+              tag: latest@sha256:22cb34ce3707c12db4a49f29b1432437833d553fa723cdcb268a8e9f5522cd96
+            env:
+              TZ: "Europe/Belgrade"
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+    persistence:
+      config:
+        type: configMap
+        name: onvif-server-config
+        globalMounts:
+          - path: /onvif.yaml
+            subPath: onvif.yaml
+            readOnly: true

--- a/kubernetes/apps/home/onvif-server/app/kustomization.yaml
+++ b/kubernetes/apps/home/onvif-server/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: home
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./configmap.yaml

--- a/kubernetes/apps/home/onvif-server/app/ocirepository.yaml
+++ b/kubernetes/apps/home/onvif-server/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: onvif-server
+  namespace: home
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/home/onvif-server/ks.yaml
+++ b/kubernetes/apps/home/onvif-server/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app onvif-server
+spec:
+  targetNamespace: home
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/home/onvif-server/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
Wraps the D4H's go2rtc RTSP stream as a virtual ONVIF camera so **UniFi Protect** (UDM-SE) can adopt it natively — giving local recording + Protect's animal/person smart-detection (the eating clips the D4H can't produce cloud-free, since it has no on-device AI).

## How it works
- `ghcr.io/daniela-hase/onvif-server` on **multus-host macvlan at 10.5.0.207** (own MAC `a2:07:20:03:00:07`) — same L2 as the UDM-SE, so Protect's ONVIF WS-Discovery multicast finds it.
- Wraps `rtsp://10.40.0.33:8554/300008810` (petkit-local go2rtc). RTSP proxied on the server's own :8554; upstream pull to 10.40.0.33 goes via the pod's cluster interface → **no cross-VLAN firewall rule needed**.
- Stateless (ConfigMap), no volsync.

## After merge — adoption steps
1. Flux reconciles → pod comes up on 10.5.0.207.
2. UniFi Protect → **Settings → System → enable "Discover Third-Party Cameras"**.
3. A device **"Onvif Cardinal / YumShare Solo"** appears → adopt it.
4. In Protect, set recording + smart-detections as desired (records to the UDM-SE / UNAS-Pro).

## Caveats (first cut — may need iteration)
- **Interface binding** is the main unknown: the server picks the NIC by MAC (`net1` macvlan). If discovery doesn't show it, that's the first thing to check.
- **Snapshots** likely 404 (go2rtc's snapshot API port isn't exposed) — thumbnails may be blank; the live stream is what matters. Can expose go2rtc :1984 later if wanted.
- **Streaming load**: Protect keeps the D4H streaming ~continuously (~82% CPU).
- Image is from Oct 2024 (ONVIF is stable); it's the reference tool.

Not urgent to merge — it's additive and isolated (own IP, no deps).