### PR TITLE
fix(home): re-pin petkit-local to nkl.3 build (undo renovate revert)

### DIFF
--- a/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
+++ b/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
               # still 1.6.0 (mutated in place) — the digest is what forces the
               # re-pull and pins exactly the fork build. Back to a plain upstream
               # tag once the fixes land upstream (PRs alex-so-3#11/#12).
-              tag: 1.6.0@sha256:0ce7edb9bda6a4e7c5ad5accd317210f4a223d1f8d13f090a0e681fd0850ac24
+              tag: 1.6.0@sha256:21f41c0ea02380938374a0f7823dd70c7b6a2697fa0b13d081b0db1873a7c936
             args:
               # The device is handed only the api-url host for MQTT and media
               # uploads, on firmware-fixed ports (443/9000) — so this must stay


### PR DESCRIPTION
Renovate reverted petkit-local to unpatched upstream 1.6.0. containers#444 re-pins the fork build (renovate off), so 1.6.0 = the fork again. Pin digest `21f41c0e` — all D4H fixes incl. camera-feeder clip upload.