### PR TITLE
fix(home): petkit-local nkl.4 (feed-clip upload)

### DIFF
--- a/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
+++ b/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
               # still 1.6.0 (mutated in place) — the digest is what forces the
               # re-pull and pins exactly the fork build. Back to a plain upstream
               # tag once the fixes land upstream (PRs alex-so-3#11/#12).
-              tag: 1.6.0@sha256:21f41c0ea02380938374a0f7823dd70c7b6a2697fa0b13d081b0db1873a7c936
+              tag: 1.6.0@sha256:445106e6e328a759e94584bea9fbe0180b34c1eeb6fd6fdd4ecb73e7d1f8e2ad
             args:
               # The device is handed only the api-url host for MQTT and media
               # uploads, on firmware-fixed ports (443/9000) — so this must stay


### PR DESCRIPTION
Pin nkl.4 digest 445106e6 — seeds feedPicture/eatVideo/upload so the D4H stages+uploads feed clips (second gate).