### PR TITLE
fix(home): petkit-local nkl.6 (bucket cert SAN)

### DIFF
--- a/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
+++ b/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
               # still 1.6.0 (mutated in place) — the digest is what forces the
               # re-pull and pins exactly the fork build. Back to a plain upstream
               # tag once the fixes land upstream (PRs alex-so-3#11/#12).
-              tag: 1.6.0@sha256:5b871a38352e80e2cb4a474be480bd5906aa55a225700fdaecec89c12a2b1173
+              tag: 1.6.0@sha256:a1f54463b2d60d12dbc18cc2e5b917f4be0e3a0c42415e2ecd8cec31c8e73e04
             args:
               # The device is handed only the api-url host for MQTT and media
               # uploads, on firmware-fixed ports (443/9000) — so this must stay


### PR DESCRIPTION
Pin nkl.6 a1f54463 — bucket TLS cert now includes the LB IP in SAN so the device completes the media upload.