### PR TITLE
fix(home): petkit-local nkl.7 (bucket-cert urlparse fix)

### DIFF
--- a/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
+++ b/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
               # still 1.6.0 (mutated in place) — the digest is what forces the
               # re-pull and pins exactly the fork build. Back to a plain upstream
               # tag once the fixes land upstream (PRs alex-so-3#11/#12).
-              tag: 1.6.0@sha256:a1f54463b2d60d12dbc18cc2e5b917f4be0e3a0c42415e2ecd8cec31c8e73e04
+              tag: 1.6.0@sha256:c48944147edefe3e4cd46b3a9c1a4361cd37b2d2e3aa5f547914021ad6ef2618
             args:
               # The device is handed only the api-url host for MQTT and media
               # uploads, on firmware-fixed ports (443/9000) — so this must stay


### PR DESCRIPTION
Pin nkl.7 c4894414 — fixes the NameError that made the bucket fall back to plain HTTP; cert now regenerates with the LB IP in SAN.