### PR TITLE
fix(home): petkit-local nkl.8 (cameraMultiNew camera_enable fix)

### DIFF
--- a/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
+++ b/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
@@ -26,12 +26,15 @@ spec:
               repository: quay.io/nklmilojevic/petkit-local
               # Built from the nklmilojevic/petkit-local fork (containers#442),
               # carrying the D4H fixes: BLE provisioning, camera feeder IP,
-              # desiccant countdown, battery-installed. The containers pipeline
-              # strips the fork's -nkl.N prerelease suffix, so the image tag is
-              # still 1.6.0 (mutated in place) — the digest is what forces the
-              # re-pull and pins exactly the fork build. Back to a plain upstream
-              # tag once the fixes land upstream (PRs alex-so-3#11/#12).
-              tag: 1.6.0@sha256:c48944147edefe3e4cd46b3a9c1a4361cd37b2d2e3aa5f547914021ad6ef2618
+              # desiccant countdown, battery-installed, feed-clip upload chain,
+              # and (nkl.8) the cameraMultiNew schedule-object fix that finally
+              # sets camera_enable so feed snapshots + eat clips record and
+              # upload. The containers pipeline strips the fork's -nkl.N
+              # prerelease suffix, so the image tag is still 1.6.0 (mutated in
+              # place) — the digest is what forces the re-pull and pins exactly
+              # the fork build. Back to a plain upstream tag once the fixes land
+              # upstream (PRs alex-so-3#11/#12).
+              tag: 1.6.0@sha256:11c1eece3ab324bb3a3f2e8ae3d60a635ed334d5370dccfe1e46e4877c38e9d1
             args:
               # The device is handed only the api-url host for MQTT and media
               # uploads, on firmware-fixed ports (443/9000) — so this must stay


### PR DESCRIPTION
Pins petkit-local to the **v1.6.0-nkl.8** fork build (containers#450, image digest `sha256:11c1eece…`).

## What this fixes — the last gate on feed/eat clip uploads

RE of the D4H `ctrl` binary plus a captured real-cloud `dev_multi_config` response showed the camera-schedule field `cameraMultiNew` must be an array of schedule **objects** `{enable,rpt,time}` (the shape the real PetKit cloud sends, and the one the litter path already used). The fork was sending a bare `[[0,1440]]` pair → firmware parse fails (`parse cameraMultiNew fail, data null`) → `camera_enable` never set → camera encoder stays off (`camera not enable, not update the compare picture`) → every feed/eat reports `media:0` with nothing to upload.

nkl.8 emits the object form so `camera_enable=1` all day, and feed snapshots + eat clips finally record and upload to the local bucket. All upstream gates (subscription, OCI token, parUrl `:9000`, TLS SAN, feedPicture/eatVideo/upload) were already verified working.