### PR TITLE
fix(home): petkit-local nkl.9 (bucket cert TLS-verify fix)

### DIFF
--- a/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
+++ b/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
@@ -27,14 +27,16 @@ spec:
               # Built from the nklmilojevic/petkit-local fork (containers#442),
               # carrying the D4H fixes: BLE provisioning, camera feeder IP,
               # desiccant countdown, battery-installed, feed-clip upload chain,
-              # and (nkl.8) the cameraMultiNew schedule-object fix that finally
-              # sets camera_enable so feed snapshots + eat clips record and
-              # upload. The containers pipeline strips the fork's -nkl.N
+              # (nkl.8) the cameraMultiNew schedule-object fix that sets
+              # camera_enable so feed snapshots + eat clips are recorded, and
+              # (nkl.9) the bucket-cert fix (CA:TRUE + IP-as-DNS SAN) so the
+              # cloud uploader's strict TLS verify accepts the cert and the
+              # clips actually upload. The containers pipeline strips the fork's -nkl.N
               # prerelease suffix, so the image tag is still 1.6.0 (mutated in
               # place) — the digest is what forces the re-pull and pins exactly
               # the fork build. Back to a plain upstream tag once the fixes land
               # upstream (PRs alex-so-3#11/#12).
-              tag: 1.6.0@sha256:11c1eece3ab324bb3a3f2e8ae3d60a635ed334d5370dccfe1e46e4877c38e9d1
+              tag: 1.6.0@sha256:d7c23bb42657a00cde93b0fda9655a570d26d54eacfe86b3023b26713de8ac99
             args:
               # The device is handed only the api-url host for MQTT and media
               # uploads, on firmware-fixed ports (443/9000) — so this must stay


### PR DESCRIPTION
Pins petkit-local to **v1.6.0-nkl.9** (containers#451, digest `sha256:d7c23bb4…`).

## The final upload gate: cloud TLS verification

After nkl.8 fixed `camera_enable` (clips are now captured and staged in `/tmp`), the `cloud` media uploader (libcurl + **OpenSSL 1.0.0**, strict `VERIFYHOST`) still rejected the bucket cert — `SSL peer certificate or SSH remote key was not OK` — so every media PUT failed while the non-verifying devlog path kept working. Two causes, both fixed in the fork:

1. Old curl/openssl matches the connect host against CN and **DNS**-type SANs, not reliably against `iPAddress` SANs. The device connects to the bucket by IP, so an IP-only SAN failed `verifyhost`. Each IP is now added as **both** IP and DNS SAN.
2. The self-signed cert had no `basicConstraints`; now `CA:TRUE` + `keyUsage(keyCertSign)` + SKI/AKI, and it force-regenerates a stale non-CA cert on upgrade.

**Post-deploy:** the `cacert` patch is re-applied so the device trusts the regenerated cert (that patcher reboots the device, so the cloud process reloads the bundle). Then feed snapshots / eat clips upload to the local bucket.