### PR TITLE
fix(home): petkit-local nkl.10 (feed counters, feedSound, cacert dedup)

### DIFF
--- a/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
+++ b/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
@@ -31,12 +31,15 @@ spec:
               # camera_enable so feed snapshots + eat clips are recorded, and
               # (nkl.9) the bucket-cert fix (CA:TRUE + IP-as-DNS SAN) so the
               # cloud uploader's strict TLS verify accepts the cert and the
-              # clips actually upload. The containers pipeline strips the fork's -nkl.N
+              # clips actually upload, and (nkl.10) feed-total counters +
+              # feedSound remap + a cacert patcher that dedups the CA bundle so
+              # the duplicate-cert collision that broke uploads cannot recur.
+              # The containers pipeline strips the fork's -nkl.N
               # prerelease suffix, so the image tag is still 1.6.0 (mutated in
               # place) — the digest is what forces the re-pull and pins exactly
               # the fork build. Back to a plain upstream tag once the fixes land
               # upstream (PRs alex-so-3#11/#12).
-              tag: 1.6.0@sha256:d7c23bb42657a00cde93b0fda9655a570d26d54eacfe86b3023b26713de8ac99
+              tag: 1.6.0@sha256:a94d083181456f6b978d9920f2f8d5dce34fce7d34037a8a2dc1df56c4df0a18
             args:
               # The device is handed only the api-url host for MQTT and media
               # uploads, on firmware-fixed ports (443/9000) — so this must stay


### PR DESCRIPTION
Pins petkit-local to **v1.6.0-nkl.10** (containers#452, digest `sha256:a94d0831…`).

Polish on top of the now-working camera pipeline:
- **Feed-total counters** — `Times Dispensed` / `Total Dispensed` now populate (aggregated from `feed_over` events, daily reset; jammed feeds excluded). The D4H never reports `feedState`, so the cloud-equivalent aggregation is done locally.
- **Feed Sound** — remapped to the field the D4H actually exposes (`soundEnable`); read-mirror + write-both so the toggle works.
- **cacert dedup (durability)** — the patcher now strips prior copies of our cert before appending, leaving exactly one. This removes the manual CA-bundle cleanup and prevents the duplicate-`CN=petkit-local` collision (OpenSSL 1.0.0 anchoring on a stale cert) from ever silently breaking uploads again. Re-applying the patch is now idempotent.

Genuinely N/A on D4H hardware (no bowl scale): Food-in-Bowl grams, Amount Eaten. Feeding Schedule stays `{}` until a schedule is set.