### PR TITLE
fix(home): petkit-local nkl.11 (Food Low sensor inversion)

### DIFF
--- a/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
+++ b/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
@@ -39,7 +39,7 @@ spec:
               # place) — the digest is what forces the re-pull and pins exactly
               # the fork build. Back to a plain upstream tag once the fixes land
               # upstream (PRs alex-so-3#11/#12).
-              tag: 1.6.0@sha256:a94d083181456f6b978d9920f2f8d5dce34fce7d34037a8a2dc1df56c4df0a18
+              tag: 1.6.0@sha256:96111d1e8b1e4bb4e772a898bc1bfcf8f8a9cfdd50aa4b29dd722e1c9e1931e8
             args:
               # The device is handed only the api-url host for MQTT and media
               # uploads, on firmware-fixed ports (443/9000) — so this must stay


### PR DESCRIPTION
Pins petkit-local to **v1.6.0-nkl.11** (containers#453, digest `sha256:96111d1e…`).

Fixes the "Food Low" binary_sensor: it read `state.food` through HA's generic *"any truthy value = problem"* template, but the D4H reports `food=2` as its normal **full-hopper** state — so a full dispenser was permanently flagged "Food Low: on". Now derives `state.foodLow` (low only when `food==0`) so a full hopper reads off.