### PR TITLE
fix(home): petkit-local nkl.12 (persist feed counters)

### DIFF
--- a/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
+++ b/kubernetes/apps/home/petkit-local/app/helmrelease.yaml
@@ -39,7 +39,7 @@ spec:
               # place) — the digest is what forces the re-pull and pins exactly
               # the fork build. Back to a plain upstream tag once the fixes land
               # upstream (PRs alex-so-3#11/#12).
-              tag: 1.6.0@sha256:96111d1e8b1e4bb4e772a898bc1bfcf8f8a9cfdd50aa4b29dd722e1c9e1931e8
+              tag: 1.6.0@sha256:61f2e67d0a035883f8996ff4b81694f09aae2e6959c718a8bb0381f10fc1c09a
             args:
               # The device is handed only the api-url host for MQTT and media
               # uploads, on firmware-fixed ports (443/9000) — so this must stay


### PR DESCRIPTION
Pins petkit-local to **v1.6.0-nkl.12** (containers#454, digest `sha256:61f2e67d…`). Persists `feedState` (Times/Total Dispensed) so the running daily totals survive pod restarts/deploys instead of resetting to zero mid-day.