### PR TITLE
feat(kopiur): add kopiur kopia backups alongside volsync (miroir phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This is a Kubernetes homelab repository using Flux CD for GitOps, managing ~40 a
 - **Helm Charts**: bjw-s app-template (v5.0.1) for most apps, declared per-app via `OCIRepository`
 - **Secrets**: External Secrets + 1Password Connect (runtime app secrets); bootstrap secrets injected via `vals` from `ref+op://` 1Password service-account refs (no SOPS)
 - **Storage**: Rook-Ceph (distributed), OpenEBS (local), NFS (shared media)
-- **Backups**: VolSync with R2 backend, wired in via a shared Kustomize Component
+- **Backups**: kopiur (kopia snapshots to the `r2` ClusterRepository) via the `components/kopiur/backup` Component, running alongside legacy VolSync restic during the rook-ceph → miroir migration
 - **Automation**: `just` (recipe runner; modules under `.just/`), Renovate (Mend app + `.renovate/` config)
 - **Dev shell**: Nix flake (`flake.nix`); pre-commit via `lefthook.yml` (yamlfmt + yamllint)
 
@@ -30,7 +30,10 @@ kubernetes/
 │   │           ├── externalsecret.yaml  # (optional)
 │   │           └── pvc.yaml             # (optional, extra PVCs beyond the volsync one)
 ├── components/
-│   └── volsync/             # Reusable Kustomize Component (kind: Component), wired via ks.yaml `components:`
+│   ├── kopiur/
+│   │   ├── backup/          # SnapshotPolicy + SnapshotSchedule per app, wired via ks.yaml `components:`
+│   │   └── secret/          # kopiur-repository ExternalSecret, wired once per namespace kustomization
+│   └── volsync/             # Legacy Component (kind: Component), wired via ks.yaml `components:`
 │       ├── kustomization.yaml
 │       ├── externalsecret.yaml
 │       ├── pvc.yaml
@@ -87,6 +90,7 @@ metadata:
   name: &app {app-name}
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: {namespace}
   commonMetadata:
@@ -97,6 +101,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/{namespace}/{app}/app
@@ -336,7 +342,8 @@ There are no global cluster variable ConfigMaps/Secrets in this repo; domains an
 ## Important Notes
 
 - Never commit secret material — bootstrap secrets are plaintext YAML carrying `ref+op://` vals references (resolved from 1Password at apply time, no actual secret values), and runtime app secrets come from External Secrets + 1Password Connect
-- Backups are wired in via the volsync Kustomize Component (`components:` in `ks.yaml`), not by listing resources in `app/kustomization.yaml`
+- Backups are wired in via the kopiur/backup and volsync Kustomize Components (`components:` in `ks.yaml`), not by listing resources in `app/kustomization.yaml`; both run in parallel during the rook-ceph → miroir migration (kopiur is the go-forward system)
+- A namespace with kopiur-backed apps must include `../../components/kopiur/secret` in its `kustomization.yaml` (movers read `kopiur-repository-secret` from their own namespace); kopiur reuses the `VOLSYNC_*` postBuild vars until the volsync component is retired
 - Use YAML anchors (`&app`, `&port`) for DRY configuration
 - Each app carries its own `ocirepository.yaml`; there is no centralized app-template OCIRepository
 - Do not repeat HelmRelease `install`/`upgrade` remediation — it is injected by `flux/apps.yaml` (opt out with label `flux.home/helm-defaults: skip`)

--- a/kubernetes/apps/ai/hermes/ks.yaml
+++ b/kubernetes/apps/ai/hermes/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app hermes
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: ai
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/ai/hermes/app

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: ai
+components:
+  - ../../components/kopiur/secret
 resources:
   - ./namespace.yaml
   - ./toolhive/ks.yaml

--- a/kubernetes/apps/ai/memini/ks.yaml
+++ b/kubernetes/apps/ai/memini/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app memini
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: ai
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
     - name: llmkube-models

--- a/kubernetes/apps/home/appdaemon/ks.yaml
+++ b/kubernetes/apps/home/appdaemon/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app appdaemon
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: home-assistant
       namespace: home
     - name: external-secrets-stores

--- a/kubernetes/apps/home/esphome/ks.yaml
+++ b/kubernetes/apps/home/esphome/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app esphome
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
@@ -18,6 +19,8 @@ spec:
       namespace: network
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/home/esphome/app

--- a/kubernetes/apps/home/govee2mqtt/ks.yaml
+++ b/kubernetes/apps/home/govee2mqtt/ks.yaml
@@ -6,12 +6,15 @@ metadata:
   name: &app govee2mqtt
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/home/govee2mqtt/app

--- a/kubernetes/apps/home/home-assistant/ks.yaml
+++ b/kubernetes/apps/home/home-assistant/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app home-assistant
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
@@ -18,6 +19,8 @@ spec:
       namespace: network
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/home/home-assistant/app

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: home
+components:
+  - ../../components/kopiur/secret
 resources:
   - ./namespace.yaml
   - ./home-assistant/ks.yaml

--- a/kubernetes/apps/home/matter-server/ks.yaml
+++ b/kubernetes/apps/home/matter-server/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app matter-server
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
@@ -18,6 +19,8 @@ spec:
       namespace: network
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/home/matter-server/app

--- a/kubernetes/apps/home/music-assistant/ks.yaml
+++ b/kubernetes/apps/home/music-assistant/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app music-assistant
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
@@ -18,6 +19,8 @@ spec:
       namespace: network
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/home/music-assistant/app

--- a/kubernetes/apps/home/otbr/ks.yaml
+++ b/kubernetes/apps/home/otbr/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app otbr
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
@@ -18,6 +19,8 @@ spec:
       namespace: network
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/home/otbr/app

--- a/kubernetes/apps/home/petkit-local/ks.yaml
+++ b/kubernetes/apps/home/petkit-local/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app petkit-local
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/home/petkit-local/app

--- a/kubernetes/apps/home/scrypted/ks.yaml
+++ b/kubernetes/apps/home/scrypted/ks.yaml
@@ -6,12 +6,15 @@ metadata:
   name: &app scrypted
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/home/scrypted/app

--- a/kubernetes/apps/home/wyoming-onnx-asr/ks.yaml
+++ b/kubernetes/apps/home/wyoming-onnx-asr/ks.yaml
@@ -6,11 +6,15 @@ metadata:
   name: &app wyoming-onnx-asr
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  dependsOn:
+    - name: kopiur
+      namespace: kopiur-system
   path: ./kubernetes/apps/home/wyoming-onnx-asr/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/home/z2mqtt/ks.yaml
+++ b/kubernetes/apps/home/z2mqtt/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app z2mqtt
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
@@ -23,6 +24,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
     - name: mosquitto

--- a/kubernetes/apps/kopiur-system/kopiur/app/externalsecret.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kopiur-endpoint
+  namespace: kopiur-system
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: onepassword-connect
+    kind: ClusterSecretStore
+  target:
+    name: kopiur-endpoint
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        R2_ENDPOINT: "{{ .R2_ENDPOINT }}"
+  dataFrom:
+    - extract:
+        key: kopiur

--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kopiur
+  namespace: kopiur-system
+spec:
+  interval: 5m
+  chartRef:
+    kind: OCIRepository
+    name: kopiur
+  values:
+    monitoring:
+      dashboards:
+        enabled: true
+        grafanaOperator:
+          enabled: true
+          matchLabels:
+            dashboards: grafana
+      prometheusRule:
+        enabled: true
+      serviceMonitor:
+        enabled: true
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
+    resources:
+      requests:
+        cpu: 100m
+      limits:
+        memory: 2Gi

--- a/kubernetes/apps/kopiur-system/kopiur/app/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kopiur-system
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kopiur
+  namespace: kopiur-system
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.9.2
+  url: oci://ghcr.io/home-operations/charts/kopiur

--- a/kubernetes/apps/kopiur-system/kopiur/ks.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/ks.yaml
@@ -1,0 +1,57 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kopiur
+spec:
+  targetNamespace: kopiur-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: snapshot-controller
+      namespace: security
+    - name: external-secrets-stores
+      namespace: security
+  path: ./kubernetes/apps/kopiur-system/kopiur/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kopiur-repository
+spec:
+  targetNamespace: kopiur-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: kopiur
+      namespace: kopiur-system
+  path: ./kubernetes/apps/kopiur-system/kopiur/repository
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    # The R2 account endpoint is kept out of Git (public repo); it is synced
+    # from the 1Password `kopiur` item into the kopiur-endpoint Secret by the
+    # ExternalSecret in ./app.
+    substituteFrom:
+      - kind: Secret
+        name: kopiur-endpoint

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/clusterrepository_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: ClusterRepository
+metadata:
+  name: r2
+spec:
+  allowedNamespaces:
+    all: true
+  backend:
+    s3:
+      auth:
+        secretRef:
+          name: kopiur-repository-secret
+          namespace: kopiur-system
+      bucket: kopiur
+      endpoint: ${R2_ENDPOINT}
+      region: auto
+  encryption:
+    passwordSecretRef:
+      name: kopiur-repository-secret
+      namespace: kopiur-system
+      key: KOPIA_PASSWORD
+  scheduleDefaults:
+    timezone: Europe/Belgrade

--- a/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./clusterrepository.yaml

--- a/kubernetes/apps/kopiur-system/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kustomization.yaml
@@ -1,12 +1,9 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: security
+namespace: kopiur-system
 components:
   - ../../components/kopiur/secret
 resources:
   - ./namespace.yaml
-  - ./external-secrets/ks.yaml
-  - ./volsync/ks.yaml
-  - ./snapshot-controller/ks.yaml
-  - ./atuin/ks.yaml
+  - ./kopiur/ks.yaml

--- a/kubernetes/apps/kopiur-system/namespace.yaml
+++ b/kubernetes/apps/kopiur-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kopiur-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/media/bazarr/ks.yaml
+++ b/kubernetes/apps/media/bazarr/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app bazarr
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/media/bazarr/app

--- a/kubernetes/apps/media/bookboss/ks.yaml
+++ b/kubernetes/apps/media/bookboss/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app bookboss
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/media/bookboss/app

--- a/kubernetes/apps/media/jellyfin/ks.yaml
+++ b/kubernetes/apps/media/jellyfin/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app jellyfin
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
@@ -23,6 +24,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   interval: 30m

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: media
+components:
+  - ../../components/kopiur/secret
 resources:
   - ./namespace.yaml
   - ./chaski/ks.yaml

--- a/kubernetes/apps/media/plex-trakt-sync/ks.yaml
+++ b/kubernetes/apps/media/plex-trakt-sync/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app plex-trakt-sync
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
@@ -23,6 +24,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
   interval: 30m
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app plex
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
@@ -23,6 +24,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   interval: 30m

--- a/kubernetes/apps/media/profilarr/ks.yaml
+++ b/kubernetes/apps/media/profilarr/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app profilarr
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
   path: ./kubernetes/apps/media/profilarr/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app prowlarr
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/media/prowlarr/app

--- a/kubernetes/apps/media/qbittorrent/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app qbittorrent
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/media/qbittorrent/app

--- a/kubernetes/apps/media/qui/ks.yaml
+++ b/kubernetes/apps/media/qui/ks.yaml
@@ -6,12 +6,15 @@ metadata:
   name: &app qui
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: kopiur
+      namespace: kopiur-system
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: external-secrets-stores

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app radarr
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/media/radarr/app

--- a/kubernetes/apps/media/sabnzbd/ks.yaml
+++ b/kubernetes/apps/media/sabnzbd/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app sabnzbd
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: openebs
       namespace: openebs-system
     - name: volsync

--- a/kubernetes/apps/media/shelfmark/ks.yaml
+++ b/kubernetes/apps/media/shelfmark/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app shelfmark
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
   path: ./kubernetes/apps/media/shelfmark/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/media/slskd/ks.yaml
+++ b/kubernetes/apps/media/slskd/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app slskd
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/media/slskd/app

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app sonarr
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/media/sonarr/app

--- a/kubernetes/apps/media/tautulli/ks.yaml
+++ b/kubernetes/apps/media/tautulli/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app tautulli
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
@@ -23,6 +24,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
   interval: 30m
   retryInterval: 1m
   timeout: 5m

--- a/kubernetes/apps/media/unpackerr/ks.yaml
+++ b/kubernetes/apps/media/unpackerr/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app unpackerr
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
   path: ./kubernetes/apps/media/unpackerr/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/misc/forgejo/ks.yaml
+++ b/kubernetes/apps/misc/forgejo/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app forgejo
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: misc
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/misc/forgejo/app

--- a/kubernetes/apps/misc/invoicing/ks.yaml
+++ b/kubernetes/apps/misc/invoicing/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app invoicing
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: misc
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/misc/invoicing/app

--- a/kubernetes/apps/misc/kustomization.yaml
+++ b/kubernetes/apps/misc/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: misc
+components:
+  - ../../components/kopiur/secret
 resources:
   - ./namespace.yaml
   - ./paperless/ks.yaml

--- a/kubernetes/apps/misc/manyfold/ks.yaml
+++ b/kubernetes/apps/misc/manyfold/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app manyfold
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: misc
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
     - name: redis-manyfold

--- a/kubernetes/apps/misc/n8n/ks.yaml
+++ b/kubernetes/apps/misc/n8n/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app n8n
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: misc
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/misc/n8n/app

--- a/kubernetes/apps/misc/paperless/ks.yaml
+++ b/kubernetes/apps/misc/paperless/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app paperless
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: misc
   commonMetadata:
@@ -16,6 +17,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
     - name: external-secrets-stores
       namespace: security
   path: ./kubernetes/apps/misc/paperless/app

--- a/kubernetes/apps/security/atuin/ks.yaml
+++ b/kubernetes/apps/security/atuin/ks.yaml
@@ -5,8 +5,12 @@ metadata:
   name: &app atuin
 spec:
   components:
+    - ../../../../components/kopiur/backup
     - ../../../../components/volsync
   targetNamespace: security
+  dependsOn:
+    - name: kopiur
+      namespace: kopiur-system
   path: ./kubernetes/apps/security/atuin/app
   prune: true
   sourceRef:

--- a/kubernetes/components/kopiur/backup/kustomization.yaml
+++ b/kubernetes/components/kopiur/backup/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./snapshotpolicy.yaml
+  - ./snapshotschedule.yaml

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: "${APP}"
+spec:
+  compression:
+    compressor: zstd
+  mover:
+    cache:
+      capacity: "${VOLSYNC_CACHE_CAPACITY:-1Gi}"
+      mode: Persistent
+      storageClassName: "${VOLSYNC_CACHE_SNAPSHOTCLASS:-openebs-hostpath}"
+    securityContext:
+      runAsUser: ${APP_UID:-1000}
+      runAsGroup: ${APP_GID:-1000}
+  repository:
+    kind: ClusterRepository
+    name: r2
+  retention:
+    keepLatest: 3
+    keepDaily: 7
+  sources:
+    - pvc:
+        name: "${VOLSYNC_CLAIM:-${APP}}"
+  volumeSnapshotClassName: "${VOLSYNC_SNAPSHOTCLASS:-csi-ceph-blockpool}"

--- a/kubernetes/components/kopiur/backup/snapshotschedule.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotschedule.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: "${APP}"
+spec:
+  policyRef:
+    name: "${APP}"
+  schedule:
+    cron: "H 0 * * *"
+    timezone: Europe/Belgrade

--- a/kubernetes/components/kopiur/secret/externalsecret.yaml
+++ b/kubernetes/components/kopiur/secret/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kopiur-repository
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: onepassword-connect
+    kind: ClusterSecretStore
+  target:
+    name: kopiur-repository-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        KOPIA_PASSWORD: "{{ .KOPIA_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: kopiur

--- a/kubernetes/components/kopiur/secret/kustomization.yaml
+++ b/kubernetes/components/kopiur/secret/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./externalsecret.yaml


### PR DESCRIPTION
## Summary

Phase 1 of the rook-ceph → miroir migration: deploy [kopiur](https://kopiur.home-operations.com/) (kopia-native backup operator) and start taking kopia backups of every volsync-backed PVC to a new R2 bucket, **in parallel** with the existing VolSync restic backups. Layout follows the [maintainer's setup](https://github.com/onedr0p/home-ops/tree/main/kubernetes/apps/kopiur-system).

### New

- `kubernetes/apps/kopiur-system/` — kopiur operator (chart `0.9.2`), split into `kopiur` (app) and `kopiur-repository` (ClusterRepository `r2`) Kustomizations. ServiceMonitor, PrometheusRule, and grafana-operator dashboard enabled.
- `kubernetes/components/kopiur/backup/` — per-app `SnapshotPolicy` + `SnapshotSchedule` (daily `H 0 * * *`, Europe/Belgrade, zstd, keepLatest 3 / keepDaily 7). Reuses the existing `VOLSYNC_*` postBuild vars so app `ks.yaml` substitutions stay untouched.
- `kubernetes/components/kopiur/secret/` — `kopiur-repository` ExternalSecret stamped once per namespace (movers read credentials from their own namespace).

### Changed

- 35 app `ks.yaml`: added `components/kopiur/backup` + `dependsOn: kopiur`.
- 5 namespace `kustomization.yaml` (ai/home/media/misc/security) + `kopiur-system`: added `components/kopiur/secret`.
- CLAUDE.md updated for the parallel-backup period.

### Secrets / infra prerequisites (before merge)

1Password item `kopiur` (homecluster vault) exists with a generated `KOPIA_PASSWORD`; still needs:
- R2 bucket `kopiur` created
- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (R2 token scoped to the bucket)
- `R2_ENDPOINT` (`<account-id>.r2.cloudflarestorage.com`) — kept out of Git via `postBuild.substituteFrom`

### Notes

- PVCs are **not** touched — the `dataSourceRef` flip to kopiur's `Restore` populator happens at the miroir cutover.
- VolSync restic keeps running until kopia retention covers the recovery window; restic repos stay frozen in R2 as fallback afterwards.