### PR TITLE
feat(talos): prep nodes for miroir (drbd extension, kernel modules, graceful shutdown)

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -55,6 +55,13 @@ machine:
       - net.ifnames=1
     image: factory.talos.dev/installer/{{ ENV.SCHEMATIC }}:v1.13.4
     wipe: false
+  kernel:
+    modules:
+      - name: dm_thin_pool # Miroir lvmthin backend
+      - name: drbd # Miroir replication (from the siderolabs/drbd extension)
+        parameters:
+          - usermode_helper=disabled
+      - name: drbd_transport_tcp
   kubelet:
     defaultRuntimeSeccompProfileEnabled: true
     disableManifestsDirectory: true
@@ -63,6 +70,9 @@ machine:
         - net.ipv6.conf.*
       imageGCHighThresholdPercent: 70
       imageGCLowThresholdPercent: 55
+      # Miroir/DRBD needs movers and replicas demoted cleanly on shutdown
+      shutdownGracePeriod: 90s
+      shutdownGracePeriodCriticalPods: 60s
     extraMounts:
       - destination: /var/openebs/local
         type: bind
@@ -193,3 +203,19 @@ cluster:
   serviceAccount:
     key: ref+op://homecluster/talos/CLUSTER_SERVICEACCOUNT_KEY
   {% endif %}
+# --- Miroir raw volume (rook-ceph → miroir cutover) ---
+# DO NOT UNCOMMENT while rook-ceph still owns the data NVMe: the disk carries a
+# raw bluestore signature (no GPT) and Talos volume provisioning must never race
+# live OSD data. At cutover: tear down rook-ceph, `talosctl wipe disk` the data
+# NVMe on each node, then uncomment and apply. Creates partlabel `r-miroir`
+# (consumed by MiroirNodeGroup as /dev/disk/by-partlabel/r-miroir).
+# The RS1D0TSSD710 model selector matches the dedicated 1TB data NVMe on all
+# three nodes regardless of device naming (icarus003's enumerates as nvme0n1).
+# ---
+# apiVersion: v1alpha1
+# kind: RawVolumeConfig
+# name: miroir
+# provisioning:
+#   diskSelector:
+#     match: disk.model == "RS1D0TSSD710" && !system_disk
+#   minSize: 1TB

--- a/talos/schematic.yaml.j2
+++ b/talos/schematic.yaml.j2
@@ -2,6 +2,7 @@
 customization:
   systemExtensions:
     officialExtensions:
+      - siderolabs/drbd # Miroir DRBD9 replication
       - siderolabs/i915
       - siderolabs/intel-ice-firmware
       - siderolabs/intel-ucode


### PR DESCRIPTION
## Summary

Phase 2 of the rook-ceph → miroir migration: Talos node prep. Everything here is **inert until nodes are upgraded/rebooted**, and safe to roll out while rook-ceph keeps running.

- `talos/schematic.yaml.j2`: add `siderolabs/drbd` system extension (DRBD9 ≥ 9.3.1 for miroir replication)
- `talos/machineconfig.yaml.j2`:
  - `machine.kernel.modules`: `dm_thin_pool` (lvmthin backend), `drbd` with `usermode_helper=disabled`, `drbd_transport_tcp`
  - kubelet `shutdownGracePeriod: 90s` / `shutdownGracePeriodCriticalPods: 60s` (clean DRBD demotion on shutdown)
  - **commented-out** `RawVolumeConfig` for the miroir partition (`r-miroir` partlabel, `disk.model == "RS1D0TSSD710" && !system_disk`)

### Why the RawVolumeConfig is commented

The data NVMe on each node still carries live rook-ceph bluestore — a raw signature with no GPT. Talos volume provisioning must never race live OSD data, so the volume config only gets uncommented at cutover, after rook-ceph teardown + `talosctl wipe disk` per node.

The model selector (`RS1D0TSSD710`) matches the dedicated 1TB data NVMe on all three nodes independent of device naming — relevant because icarus003's data disk now enumerates as `nvme0n1` (its system disk is the 300GB SATA), even though the rook cluster config still says `/dev/nvme1n1` for it.

### Rollout (after merge, one node at a time)

```
just talos upgrade-node icarus001   # new schematic image (drbd extension)
just talos apply-node icarus001     # kernel modules + kubelet shutdown config
```

Wait for ceph `HEALTH_OK` between nodes.