### PR TITLE
fix(home): run backup movers as root for root-owned app volumes

### DIFF
--- a/kubernetes/apps/home/matter-server/ks.yaml
+++ b/kubernetes/apps/home/matter-server/ks.yaml
@@ -38,3 +38,5 @@ spec:
       APP: *app
       VOLSYNC_CLAIM: matter-server-data
       VOLSYNC_CAPACITY: 1Gi
+      APP_UID: "0"
+      APP_GID: "0"

--- a/kubernetes/apps/home/music-assistant/ks.yaml
+++ b/kubernetes/apps/home/music-assistant/ks.yaml
@@ -38,3 +38,5 @@ spec:
       APP: *app
       VOLSYNC_CLAIM: music-assistant-data
       VOLSYNC_CAPACITY: 5Gi
+      APP_UID: "0"
+      APP_GID: "0"

--- a/kubernetes/apps/home/otbr/ks.yaml
+++ b/kubernetes/apps/home/otbr/ks.yaml
@@ -38,3 +38,5 @@ spec:
       APP: *app
       VOLSYNC_CLAIM: otbr-data
       VOLSYNC_CAPACITY: 1Gi
+      APP_UID: "0"
+      APP_GID: "0"


### PR DESCRIPTION
matter-server, music-assistant, and otbr run as uid 0 and write 0600
root-owned files; the kopiur mover (uid 1000 by default) cannot read them
(volsync only got away with it via its fsGroup remount relabel). Set
APP_UID/APP_GID to 0 so the movers match the apps' runtime identity.
