### PR TITLE
fix(home): permit privileged kopiur movers in the home namespace

### DIFF
--- a/kubernetes/apps/home/namespace.yaml
+++ b/kubernetes/apps/home/namespace.yaml
@@ -6,4 +6,5 @@ metadata:
   labels:
     kustomize.toolkit.fluxcd.io/prune: disabled
   annotations:
+    kopiur.home-operations.com/privileged-movers: "true"
     volsync.backube/privileged-movers: "true"


### PR DESCRIPTION
matter-server, music-assistant, and otbr run as root, so their kopia movers
must too (APP_UID=0); kopiur gates elevated movers behind a per-namespace
opt-in annotation, mirroring the existing volsync.backube/privileged-movers
grant.
