### PR TITLE
fix(talos): source Talos/Kubernetes versions from the tuppr upgrade specs

### DIFF
--- a/.just/talos.just
+++ b/.just/talos.just
@@ -1,9 +1,10 @@
-set unstable := true
-set quiet := true
+set unstable
+set quiet
 set script-interpreter := ['bash', '-euo', 'pipefail']
 set shell := ['bash', '-euo', 'pipefail', '-c']
 
 talos_dir := justfile_directory() / 'talos'
+tuppr_dir := justfile_directory() / 'kubernetes/apps/system-upgrade/tuppr/upgrades'
 
 [private]
 default:
@@ -15,6 +16,8 @@ default:
 render-config node:
     export CONTROLPLANE="$(just talos machine-controller {{ node }})"
     export SCHEMATIC="$(just talos schematic-id)"
+    export TALOS_VERSION="$(yq -e '.spec.talos.version' "{{ tuppr_dir }}/talosupgrade.yaml")"
+    export KUBERNETES_VERSION="$(yq -e '.spec.kubernetes.version' "{{ tuppr_dir }}/kubernetesupgrade.yaml")"
     talosctl machineconfig patch <(just template "{{ talos_dir }}/machineconfig.yaml.j2") \
         -p @<(just template "{{ talos_dir }}/nodes/{{ node }}.yaml.j2")
 
@@ -80,4 +83,6 @@ machine-controller node:
 [script]
 machine-image:
     export SCHEMATIC="$(just talos schematic-id)"
+    export TALOS_VERSION="$(yq -e '.spec.talos.version' "{{ tuppr_dir }}/talosupgrade.yaml")"
+    export KUBERNETES_VERSION="$(yq -e '.spec.kubernetes.version' "{{ tuppr_dir }}/kubernetesupgrade.yaml")"
     minijinja-cli "{{ talos_dir }}/machineconfig.yaml.j2" | yq -e 'select(.machine) | .machine.install.image'

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -53,7 +53,7 @@ machine:
   install:
     extraKernelArgs:
       - net.ifnames=1
-    image: factory.talos.dev/installer/{{ ENV.SCHEMATIC }}:v1.13.4
+    image: factory.talos.dev/installer/{{ ENV.SCHEMATIC }}:{{ ENV.TALOS_VERSION }}
     wipe: false
   kernel:
     modules:
@@ -81,7 +81,7 @@ machine:
           - bind
           - rshared
           - rw
-    image: ghcr.io/siderolabs/kubelet:v1.36.2
+    image: ghcr.io/siderolabs/kubelet:{{ ENV.KUBERNETES_VERSION }}
     nodeIP:
       validSubnets:
         - 10.40.0.0/24
@@ -160,11 +160,11 @@ cluster:
     disablePodSecurityPolicy: true
     extraArgs:
       enable-aggregator-routing: "true"
-    image: registry.k8s.io/kube-apiserver:v1.36.2
+    image: registry.k8s.io/kube-apiserver:{{ ENV.KUBERNETES_VERSION }}
   controllerManager:
     extraArgs:
       bind-address: 0.0.0.0
-    image: registry.k8s.io/kube-controller-manager:v1.36.2
+    image: registry.k8s.io/kube-controller-manager:{{ ENV.KUBERNETES_VERSION }}
   coreDNS:
     disabled: true
   etcd:
@@ -177,7 +177,7 @@ cluster:
       listen-metrics-urls: http://0.0.0.0:2381
   proxy:
     disabled: true
-    image: registry.k8s.io/kube-proxy:v1.36.2
+    image: registry.k8s.io/kube-proxy:{{ ENV.KUBERNETES_VERSION }}
   scheduler:
     config:
       apiVersion: kubescheduler.config.k8s.io/v1
@@ -198,7 +198,7 @@ cluster:
                     whenUnsatisfiable: ScheduleAnyway
     extraArgs:
       bind-address: 0.0.0.0
-    image: registry.k8s.io/kube-scheduler:v1.36.2
+    image: registry.k8s.io/kube-scheduler:{{ ENV.KUBERNETES_VERSION }}
   secretboxEncryptionSecret: ref+op://homecluster/talos/CLUSTER_SECRETBOXENCRYPTIONSECRET
   serviceAccount:
     key: ref+op://homecluster/talos/CLUSTER_SERVICEACCOUNT_KEY


### PR DESCRIPTION
machineconfig.yaml.j2 pinned v1.13.4/v1.36.2 while tuppr (fed by Renovate)
had the fleet on v1.13.8/v1.36.3 — a manual upgrade-node/apply-node silently
downgraded icarus001. Template the install image and kube component images
with TALOS_VERSION/KUBERNETES_VERSION, exported by the talos recipes from
tuppr's talosupgrade.yaml and kubernetesupgrade.yaml, making tuppr the
single source of truth.
