### PR TITLE
feat(kopiur): close backup gaps before the miroir cutover

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/home/home-assistant/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./pvc.yaml
+  - ./snapshotpolicy.yaml

--- a/kubernetes/apps/home/home-assistant/app/snapshotpolicy.yaml
+++ b/kubernetes/apps/home/home-assistant/app/snapshotpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: home-assistant-media
+spec:
+  compression:
+    compressor: zstd
+  mover:
+    cache:
+      capacity: 1Gi
+      mode: Persistent
+      storageClassName: openebs-hostpath
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+  repository:
+    kind: ClusterRepository
+    name: r2
+  retention:
+    keepLatest: 3
+    keepDaily: 7
+  sources:
+    - pvc:
+        name: home-assistant-media
+  volumeSnapshotClassName: csi-ceph-blockpool
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: home-assistant-media
+spec:
+  policyRef:
+    name: home-assistant-media
+  schedule:
+    cron: "H 0 * * *"
+    timezone: Europe/Belgrade

--- a/kubernetes/apps/home/mosquitto/app/kustomization.yaml
+++ b/kubernetes/apps/home/mosquitto/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./pvc.yaml
+  - ./snapshotpolicy.yaml

--- a/kubernetes/apps/home/mosquitto/app/snapshotpolicy.yaml
+++ b/kubernetes/apps/home/mosquitto/app/snapshotpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: mosquitto
+spec:
+  compression:
+    compressor: zstd
+  mover:
+    cache:
+      capacity: 1Gi
+      mode: Persistent
+      storageClassName: openebs-hostpath
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+  repository:
+    kind: ClusterRepository
+    name: r2
+  retention:
+    keepLatest: 3
+    keepDaily: 7
+  sources:
+    - pvc:
+        name: mosquitto-data
+  volumeSnapshotClassName: csi-ceph-blockpool
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: mosquitto
+spec:
+  policyRef:
+    name: mosquitto
+  schedule:
+    cron: "H 0 * * *"
+    timezone: Europe/Belgrade

--- a/kubernetes/apps/home/petkit-local/app/kustomization.yaml
+++ b/kubernetes/apps/home/petkit-local/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./pvc.yaml
+  - ./snapshotpolicy.yaml

--- a/kubernetes/apps/home/petkit-local/app/snapshotpolicy.yaml
+++ b/kubernetes/apps/home/petkit-local/app/snapshotpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: petkit-local-media
+spec:
+  compression:
+    compressor: zstd
+  mover:
+    cache:
+      capacity: 1Gi
+      mode: Persistent
+      storageClassName: openebs-hostpath
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+  repository:
+    kind: ClusterRepository
+    name: r2
+  retention:
+    keepLatest: 3
+    keepDaily: 7
+  sources:
+    - pvc:
+        name: petkit-local-media
+  volumeSnapshotClassName: csi-ceph-blockpool
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: petkit-local-media
+spec:
+  policyRef:
+    name: petkit-local-media
+  schedule:
+    cron: "H 0 * * *"
+    timezone: Europe/Belgrade

--- a/kubernetes/apps/media/seerr/ks.yaml
+++ b/kubernetes/apps/media/seerr/ks.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 metadata:
   name: &app seerr
 spec:
+  components:
+    - ../../../../components/kopiur/backup
   targetNamespace: media
   commonMetadata:
     labels:
@@ -14,6 +16,8 @@ spec:
       namespace: rook-ceph
     - name: volsync
       namespace: security
+    - name: kopiur
+      namespace: kopiur-system
   path: ./kubernetes/apps/media/seerr/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/o11y/gatus/app/kustomization.yaml
+++ b/kubernetes/apps/o11y/gatus/app/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
   - ./prometheusrule.yaml
+  - ./snapshotpolicy.yaml
 configMapGenerator:
   - name: gatus-configmap
     files:

--- a/kubernetes/apps/o11y/gatus/app/snapshotpolicy.yaml
+++ b/kubernetes/apps/o11y/gatus/app/snapshotpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: gatus
+spec:
+  compression:
+    compressor: zstd
+  mover:
+    cache:
+      capacity: 1Gi
+      mode: Persistent
+      storageClassName: openebs-hostpath
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+  repository:
+    kind: ClusterRepository
+    name: r2
+  retention:
+    keepLatest: 3
+    keepDaily: 7
+  sources:
+    - pvc:
+        name: gatus-gatus-sidecar
+  volumeSnapshotClassName: csi-ceph-blockpool
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: gatus
+spec:
+  policyRef:
+    name: gatus
+  schedule:
+    cron: "H 0 * * *"
+    timezone: Europe/Belgrade

--- a/kubernetes/apps/o11y/grafana-operator/instance/kustomization.yaml
+++ b/kubernetes/apps/o11y/grafana-operator/instance/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./grafana.yaml
   - ./grafanadatasource.yaml
   - ./dashboards
+  - ./snapshotpolicy.yaml

--- a/kubernetes/apps/o11y/grafana-operator/instance/snapshotpolicy.yaml
+++ b/kubernetes/apps/o11y/grafana-operator/instance/snapshotpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: grafana
+spec:
+  compression:
+    compressor: zstd
+  mover:
+    cache:
+      capacity: 1Gi
+      mode: Persistent
+      storageClassName: openebs-hostpath
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+  repository:
+    kind: ClusterRepository
+    name: r2
+  retention:
+    keepLatest: 3
+    keepDaily: 7
+  sources:
+    - pvc:
+        name: grafana-pvc
+  volumeSnapshotClassName: csi-ceph-blockpool
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: grafana
+spec:
+  policyRef:
+    name: grafana
+  schedule:
+    cron: "H 0 * * *"
+    timezone: Europe/Belgrade

--- a/kubernetes/apps/o11y/health-metrics/app/kustomization.yaml
+++ b/kubernetes/apps/o11y/health-metrics/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./externalsecret.yaml
   - ./vmsingle.yaml
   - ./vmagent.yaml
+  - ./snapshotpolicy.yaml

--- a/kubernetes/apps/o11y/health-metrics/app/snapshotpolicy.yaml
+++ b/kubernetes/apps/o11y/health-metrics/app/snapshotpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: vmsingle-health
+spec:
+  compression:
+    compressor: zstd
+  mover:
+    cache:
+      capacity: 1Gi
+      mode: Persistent
+      storageClassName: openebs-hostpath
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+  repository:
+    kind: ClusterRepository
+    name: r2
+  retention:
+    keepLatest: 3
+    keepDaily: 7
+  sources:
+    - pvc:
+        name: vmsingle-health
+  volumeSnapshotClassName: csi-ceph-blockpool
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: vmsingle-health
+spec:
+  policyRef:
+    name: vmsingle-health
+  schedule:
+    cron: "H 0 * * *"
+    timezone: Europe/Belgrade

--- a/kubernetes/apps/o11y/kustomization.yaml
+++ b/kubernetes/apps/o11y/kustomization.yaml
@@ -2,6 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: o11y
+components:
+  - ../../components/kopiur/secret
 resources:
   - ./namespace.yaml
   - ./victoriametrics/ks.yaml

--- a/kubernetes/apps/o11y/namespace.yaml
+++ b/kubernetes/apps/o11y/namespace.yaml
@@ -8,4 +8,5 @@ metadata:
     # Allows drm-exporter's DRA monitor ResourceClaim (adminAccess: true).
     resource.kubernetes.io/admin-access: "true"
   annotations:
+    kopiur.home-operations.com/privileged-movers: "true"
     volsync.backube/privileged-movers: "true"

--- a/kubernetes/apps/o11y/victorialogs/app/kustomization.yaml
+++ b/kubernetes/apps/o11y/victorialogs/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml
+  - ./snapshotpolicy.yaml

--- a/kubernetes/apps/o11y/victorialogs/app/snapshotpolicy.yaml
+++ b/kubernetes/apps/o11y/victorialogs/app/snapshotpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: victorialogs
+spec:
+  compression:
+    compressor: zstd
+  mover:
+    cache:
+      capacity: 1Gi
+      mode: Persistent
+      storageClassName: openebs-hostpath
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+  repository:
+    kind: ClusterRepository
+    name: r2
+  retention:
+    keepLatest: 3
+    keepDaily: 7
+  sources:
+    - pvc:
+        name: server-volume-victorialogs-victoria-logs-single-server-0
+  volumeSnapshotClassName: csi-ceph-blockpool
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: victorialogs
+spec:
+  policyRef:
+    name: victorialogs
+  schedule:
+    cron: "H 0 * * *"
+    timezone: Europe/Belgrade

--- a/kubernetes/apps/o11y/victoriametrics/app/kustomization.yaml
+++ b/kubernetes/apps/o11y/victoriametrics/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./helmrelease.yaml
   - ./externalsecret.yaml
   - ./vmalertmanager.yaml
+  - ./snapshotpolicy.yaml

--- a/kubernetes/apps/o11y/victoriametrics/app/snapshotpolicy.yaml
+++ b/kubernetes/apps/o11y/victoriametrics/app/snapshotpolicy.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: vmsingle-vmetrics
+spec:
+  compression:
+    compressor: zstd
+  mover:
+    cache:
+      capacity: 1Gi
+      mode: Persistent
+      storageClassName: openebs-hostpath
+    securityContext:
+      runAsUser: 0
+      runAsGroup: 0
+  repository:
+    kind: ClusterRepository
+    name: r2
+  retention:
+    keepLatest: 3
+    keepDaily: 7
+  sources:
+    - pvc:
+        name: vmsingle-vmetrics-victoria-metrics-k8s-stack
+  volumeSnapshotClassName: csi-ceph-blockpool
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: vmsingle-vmetrics
+spec:
+  policyRef:
+    name: vmsingle-vmetrics
+  schedule:
+    cron: "H 0 * * *"
+    timezone: Europe/Belgrade


### PR DESCRIPTION
seerr never had the volsync component wired (VOLSYNC_CLAIM was set but
unused) — seerr-config has never been backed up; give it the kopiur backup
component. Add standalone SnapshotPolicies+Schedules for PVCs outside the
per-app component: vmsingle-health (100y health metrics), vmsingle-vmetrics,
victorialogs, grafana-pvc, gatus history, mosquitto-data,
home-assistant-media, petkit-local-media. Their movers run as root
(mixed/unknown file ownership; restores preserve ownership), gated by the
per-namespace privileged-movers annotation on o11y (home already has it).
librechat mongodb PVCs are orphaned and redis PVCs are rebuildable —
deliberately not covered.
