### PR TITLE
fix(kopiur): run gap-policy movers as the volume-owning uid

### DIFF
--- a/kubernetes/apps/home/mosquitto/app/snapshotpolicy.yaml
+++ b/kubernetes/apps/home/mosquitto/app/snapshotpolicy.yaml
@@ -13,8 +13,8 @@ spec:
       mode: Persistent
       storageClassName: openebs-hostpath
     securityContext:
-      runAsUser: 0
-      runAsGroup: 0
+      runAsUser: 1000
+      runAsGroup: 1000
   repository:
     kind: ClusterRepository
     name: r2

--- a/kubernetes/apps/home/petkit-local/app/snapshotpolicy.yaml
+++ b/kubernetes/apps/home/petkit-local/app/snapshotpolicy.yaml
@@ -13,8 +13,8 @@ spec:
       mode: Persistent
       storageClassName: openebs-hostpath
     securityContext:
-      runAsUser: 0
-      runAsGroup: 0
+      runAsUser: 1000
+      runAsGroup: 1000
   repository:
     kind: ClusterRepository
     name: r2

--- a/kubernetes/apps/o11y/grafana-operator/instance/snapshotpolicy.yaml
+++ b/kubernetes/apps/o11y/grafana-operator/instance/snapshotpolicy.yaml
@@ -13,8 +13,8 @@ spec:
       mode: Persistent
       storageClassName: openebs-hostpath
     securityContext:
-      runAsUser: 0
-      runAsGroup: 0
+      runAsUser: 472
+      runAsGroup: 10001
   repository:
     kind: ClusterRepository
     name: r2


### PR DESCRIPTION
Root movers drop all capabilities (no DAC_OVERRIDE), so root still cannot
traverse 0700 dirs owned by other uids. mosquitto and petkit-local media
volumes are uid 1000; grafana's is 472:10001.
