### PR TITLE
fix(kopiur): force fsGroup relabel on the grafana backup clone

### DIFF
--- a/kubernetes/apps/o11y/grafana-operator/instance/snapshotpolicy.yaml
+++ b/kubernetes/apps/o11y/grafana-operator/instance/snapshotpolicy.yaml
@@ -12,6 +12,9 @@ spec:
       capacity: 1Gi
       mode: Persistent
       storageClassName: openebs-hostpath
+    podSecurityContext:
+      fsGroup: 10001
+      fsGroupChangePolicy: Always
     securityContext:
       runAsUser: 472
       runAsGroup: 10001


### PR DESCRIPTION
The grafana volume has mixed ownership (472-owned data plus root-owned
png/pdf/csv dirs); relabel the disposable snapshot clone to gid 10001 with
fsGroupChangePolicy Always so the mover can read everything.
