### PR TITLE
fix(kopiur): run restore movers as the owning uid

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/snapshotpolicy.yaml
+++ b/kubernetes/apps/home/home-assistant/app/snapshotpolicy.yaml
@@ -44,6 +44,10 @@ kind: Restore
 metadata:
   name: home-assistant-media
 spec:
+  mover:
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
   policy:
     onMissingSnapshot: Continue
   source:

--- a/kubernetes/apps/home/mosquitto/app/snapshotpolicy.yaml
+++ b/kubernetes/apps/home/mosquitto/app/snapshotpolicy.yaml
@@ -44,6 +44,10 @@ kind: Restore
 metadata:
   name: mosquitto
 spec:
+  mover:
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
   policy:
     onMissingSnapshot: Continue
   source:

--- a/kubernetes/apps/home/petkit-local/app/snapshotpolicy.yaml
+++ b/kubernetes/apps/home/petkit-local/app/snapshotpolicy.yaml
@@ -44,6 +44,10 @@ kind: Restore
 metadata:
   name: petkit-local-media
 spec:
+  mover:
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
   policy:
     onMissingSnapshot: Continue
   source:

--- a/kubernetes/apps/o11y/health-metrics/app/snapshotpolicy.yaml
+++ b/kubernetes/apps/o11y/health-metrics/app/snapshotpolicy.yaml
@@ -44,6 +44,8 @@ kind: Restore
 metadata:
   name: vmsingle-health
 spec:
+  mover:
+    privilegedMode: true
   policy:
     onMissingSnapshot: Continue
   source:

--- a/kubernetes/components/kopiur/backup/restore.yaml
+++ b/kubernetes/components/kopiur/backup/restore.yaml
@@ -5,6 +5,10 @@ kind: Restore
 metadata:
   name: "${APP}-bootstrap"
 spec:
+  mover:
+    securityContext:
+      runAsUser: ${APP_UID:-1000}
+      runAsGroup: ${APP_GID:-1000}
   policy:
     onMissingSnapshot: Continue
   source:


### PR DESCRIPTION
Restore movers defaulted to kopiur's uid 65532, leaving restored files
unreadable for apps without an fsGroup relabel (atuin). Component restores
run as APP_UID/APP_GID; vmsingle-health restores with privilegedMode to
preserve its root-owned files.
