### PR TITLE
fix(media): 10Gi kopiur mover cache for plex

### DIFF
--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -33,3 +33,4 @@ spec:
       APP: *app
       KOPIUR_CLAIM: plex-config
       KOPIUR_CAPACITY: 50Gi
+      KOPIUR_CACHE_CAPACITY: 10Gi


### PR DESCRIPTION
The 50Gi plex-config restore killed the mover with the default 1Gi cache.
