### PR TITLE
feat(kopiur): hourly hash-spread backups instead of a midnight wave

### DIFF
--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -20,6 +20,7 @@ spec:
     name: r2
   retention:
     keepLatest: 3
+    keepHourly: 24
     keepDaily: 7
   staging:
     # 36 policies fire in the same midnight hour; under concurrent DRBD

--- a/kubernetes/components/kopiur/backup/snapshotschedule.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotschedule.yaml
@@ -8,5 +8,5 @@ spec:
   policyRef:
     name: "${APP}"
   schedule:
-    cron: "H 0 * * *"
+    cron: "H * * * *"
     timezone: Europe/Belgrade


### PR DESCRIPTION
36 policies staging CSI snapshots inside one hour caused 8 StagingTimedOut
failures on the first scheduled night. Match upstream: hourly H-spread crons
keep every run a small incremental and spread staging thin; keepHourly 24
added to retention (keepLatest 3 / keepDaily 7 unchanged).
