### PR TITLE
feat(media): add lidarr

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ./cobalt-web/ks.yaml
   - ./sonarr/ks.yaml
   - ./radarr/ks.yaml
+  - ./lidarr/ks.yaml
   - ./bazarr/ks.yaml
   - ./plex/ks.yaml
   - ./jellyfin/ks.yaml

--- a/kubernetes/apps/media/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/lidarr/app/helmrelease.yaml
@@ -1,0 +1,103 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: lidarr
+  namespace: media
+spec:
+  interval: 5m
+  chartRef:
+    kind: OCIRepository
+    name: lidarr
+
+  values:
+    controllers:
+      lidarr:
+        replicas: 1
+
+        containers:
+          app:
+            image:
+              repository: quay.io/nklmilojevic/lidarr
+              tag: 3.1.3.4987@sha256:8a0f2c148e55b05859b6ada073795048cb8f99ee3f733a046fa85389c22934f2
+            env:
+              TZ: "Europe/Belgrade"
+              PUID: "1000"
+              PGID: "1000"
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /ping
+                    port: 8686
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 20m
+                memory: 384Mi
+              limits:
+                memory: 2Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+        pod:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        controller: lidarr
+        ports:
+          http:
+            port: &port 8686
+
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.nikola.wtf"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: lidarr
+                port: *port
+
+    persistence:
+      config:
+        existingClaim: "{{ .Release.Name }}-config"
+      tmp:
+        type: emptyDir
+      media:
+        enabled: true
+        type: custom
+        volumeSpec:
+          nfs:
+            server: "10.5.0.10"
+            path: "/var/nfs/shared/media"
+        globalMounts:
+          - path: "/media"

--- a/kubernetes/apps/media/lidarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/lidarr/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/media/lidarr/app/ocirepository.yaml
+++ b/kubernetes/apps/media/lidarr/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: lidarr
+  namespace: media
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/media/lidarr/ks.yaml
+++ b/kubernetes/apps/media/lidarr/ks.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app lidarr
+spec:
+  components:
+    - ../../../../components/kopiur/backup
+  targetNamespace: media
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: kopiur
+      namespace: kopiur-system
+    - name: miroir-config
+      namespace: miroir-system
+    - name: external-secrets-stores
+      namespace: security
+  path: ./kubernetes/apps/media/lidarr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      APP_UID: "1000"
+      APP_GID: "1000"
+      KOPIUR_CLAIM: lidarr-config
+      KOPIUR_CAPACITY: 10Gi

--- a/kubernetes/apps/media/slskd/app/externalsecret.yaml
+++ b/kubernetes/apps/media/slskd/app/externalsecret.yaml
@@ -21,3 +21,8 @@ spec:
       remoteRef:
         key: slskd
         property: password
+    # Primary (Administrator) API key: lidarr's Tubifarry plugin talks to slskd with it
+    - secretKey: SLSKD_API_KEY
+      remoteRef:
+        key: slskd
+        property: apikey


### PR DESCRIPTION
## What

Adds Lidarr to the `media` namespace, following the sonarr/radarr layout.

- `lidarr/ks.yaml` — Flux Kustomization with the kopiur backup Component, `KOPIUR_CLAIM: lidarr-config`, `KOPIUR_CAPACITY: 10Gi`, mover uid/gid 1000 (matches the pod's runtime uid)
- `lidarr/app/helmrelease.yaml` — app-template 5.0.1, `quay.io/nklmilojevic/lidarr:3.1.3.4987`, port 8686, `/ping` readiness, read-only rootfs + `tmp` emptyDir, media NFS at `/media`, route `lidarr.nikola.wtf` via the `internal` gateway
- `lidarr/app/ocirepository.yaml` — per-app app-template chart source
- `slskd` externalsecret — adds `SLSKD_API_KEY` (primary Administrator key, new `apikey` field on the `slskd` 1Password item) so Lidarr can drive slskd

## Why the develop-branch image

Soulseek support in Lidarr comes from the [Tubifarry](https://github.com/TypNull/Tubifarry) plugin, which registers slskd as both an indexer and a download client. Plugins only exist on Lidarr's `develop`/`plugins` branches — `PluginController.cs` is present on `develop` but absent on `master`. Our image already builds with `LIDARR__UPDATE__BRANCH=develop`, so no image work is needed.

## Post-merge, in the UI

1. System → Plugins → install `https://github.com/TypNull/Tubifarry`
2. Settings → Indexers and Settings → Download Clients → add Soulseek/slskd with `http://slskd-app.media.svc.cluster.local:5030` and the API key
3. Set the music root folder on the media share

## Validation

`kustomize build` on the namespace and app dirs, `flux build ks` dry-run (HelmRelease, OCIRepository, `lidarr-config` PVC @ 10Gi, Restore, SnapshotPolicy, SnapshotSchedule all render), yamlfmt + yamllint clean.