### PR TITLE
feat(media): add beets-flask for music library management

### DIFF
--- a/kubernetes/apps/media/beets/app/externalsecret.yaml
+++ b/kubernetes/apps/media/beets/app/externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: beets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: beets-secret
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        # Pulled in by the `include:` in the beets config, so the token stays out of Git
+        secrets.yaml: |
+          discogs:
+            user_token: {{ .discogs_token | quote }}
+  data:
+    - secretKey: discogs_token
+      remoteRef:
+        key: beets
+        property: discogs_token

--- a/kubernetes/apps/media/beets/app/helmrelease.yaml
+++ b/kubernetes/apps/media/beets/app/helmrelease.yaml
@@ -1,0 +1,201 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: beets
+  namespace: media
+spec:
+  interval: 5m
+  chartRef:
+    kind: OCIRepository
+    name: beets
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    controllers:
+      beets:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          # Seed the existing 19k-track library on first start; the db on the share
+          # already carries paths rewritten from the old /srv/dev-disk-by-label-storage01 root.
+          seed-library:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.37.0
+            command:
+              - sh
+              - -c
+              - |
+                set -eu
+                if [ ! -f /config/beets/musiclibrary.db ]; then
+                  mkdir -p /config/beets
+                  cp /media/Music/Music/musiclibrary.beets-flask.db /config/beets/musiclibrary.db
+                fi
+        containers:
+          app:
+            image:
+              repository: docker.io/pspitzner/beets-flask
+              tag: v2.0.0-rc5@sha256:b7f063859fb84df726733fb014629f1c9ef66c1f40f10951699088aebaac0994
+            # Upstream's entrypoint starts as root only to remap its beetle user to
+            # USER_ID/GROUP_ID; beetle is already 1000:1000 in the image and owns
+            # /config, /logs and /repo, so launch the server directly as 1000 instead.
+            command:
+              - /bin/bash
+              - -c
+              - cd /repo && source /venv/bin/activate && ./entrypoint.sh
+            env:
+              TZ: "Europe/Belgrade"
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &port 5001
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  failureThreshold: 60
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 50m
+                memory: 512Mi
+              limits:
+                memory: 4Gi
+            # No readOnlyRootFilesystem: the bundled redis writes its dump into
+            # /repo/backend and the entrypoint creates directories outside /config.
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+    service:
+      app:
+        controller: beets
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.nikola.wtf"
+        parentRefs:
+          - name: internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: beets
+                port: *port
+    configMaps:
+      config:
+        data:
+          beets.yaml: |-
+            directory: /media/Music/Music/library
+            library: /config/beets/musiclibrary.db
+
+            plugins:
+              - musicbrainz
+              - info
+              - fetchart
+              - ftintitle
+              - fromfilename
+              - edit
+              - duplicates
+              - missing
+              - mbsync
+
+            import:
+              copy: yes
+              move: no
+              write: yes
+              detail: yes
+              duplicate_action: ask
+              log: /config/beets/import.log
+
+            # Reconstructed from the existing library layout, e.g.
+            # "16 Horsepower/(1997) Low Estate/11 Dead Run.mp3"
+            paths:
+              default: $albumartist/%if{$year,($year) }$album/$track $title
+              comp: $albumartist/%if{$year,($year) }$album/$track $title
+              singleton: $artist/$title
+
+            asciify_paths: no
+            per_disc_numbering: no
+
+            fetchart:
+              auto: yes
+              cover_names:
+                - cover
+                - front
+                - folder
+
+            ui:
+              color: yes
+          beets-flask.yaml: |-
+            gui:
+              num_preview_workers: 4
+              library:
+                artist_separators: [",", ";", "&"]
+              terminal:
+                start_path: /media/Download/soulseek/complete
+              inbox:
+                folders:
+                  soulseek:
+                    name: Soulseek
+                    path: /media/Download/soulseek/complete
+                    autotag: "preview"
+    persistence:
+      config:
+        existingClaim: beets-config
+        globalMounts:
+          - path: /config
+      config-files:
+        type: configMap
+        identifier: config
+        globalMounts:
+          - path: /config/beets/config.yaml
+            subPath: beets.yaml
+            readOnly: true
+          - path: /config/beets-flask/config.yaml
+            subPath: beets-flask.yaml
+            readOnly: true
+      media:
+        type: custom
+        volumeSpec:
+          nfs:
+            server: "10.5.0.10"
+            path: "/var/nfs/shared/media"
+        globalMounts:
+          - path: /media
+      logs:
+        type: emptyDir
+        globalMounts:
+          - path: /logs
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/media/beets/app/helmrelease.yaml
+++ b/kubernetes/apps/media/beets/app/helmrelease.yaml
@@ -46,12 +46,17 @@ spec:
             # Upstream's entrypoint starts as root only to remap its beetle user to
             # USER_ID/GROUP_ID; beetle is already 1000:1000 in the image and owns
             # /config, /logs and /repo, so launch the server directly as 1000 instead.
+            # entrypoint_user_scripts.sh is upstream's extension point: it installs
+            # /config/requirements.txt (the discogs client) into the venv on boot.
             command:
               - /bin/bash
               - -c
-              - cd /repo && source /venv/bin/activate && ./entrypoint.sh
+              - cd /repo && source /venv/bin/activate && ./entrypoint_user_scripts.sh && ./entrypoint.sh
             env:
               TZ: "Europe/Belgrade"
+              # Normally set by the `su beetle` we skip; uv's cache and the web
+              # terminal's tmux both need it.
+              HOME: /home/beetle
             probes:
               liveness:
                 enabled: true
@@ -113,12 +118,18 @@ spec:
     configMaps:
       config:
         data:
+          requirements.txt: |-
+            python3-discogs-client>=2.3.15
           beets.yaml: |-
             directory: /media/Music/Music/library
             library: /config/beets/musiclibrary.db
 
+            # Discogs user_token, rendered from 1Password by the ExternalSecret
+            include: secrets.yaml
+
             plugins:
               - musicbrainz
+              - discogs
               - info
               - fetchart
               - ftintitle
@@ -182,6 +193,16 @@ spec:
             readOnly: true
           - path: /config/beets-flask/config.yaml
             subPath: beets-flask.yaml
+            readOnly: true
+          - path: /config/requirements.txt
+            subPath: requirements.txt
+            readOnly: true
+      secret-files:
+        type: secret
+        name: beets-secret
+        globalMounts:
+          - path: /config/beets/secrets.yaml
+            subPath: secrets.yaml
             readOnly: true
       media:
         type: custom

--- a/kubernetes/apps/media/beets/app/kustomization.yaml
+++ b/kubernetes/apps/media/beets/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: media
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/media/beets/app/kustomization.yaml
+++ b/kubernetes/apps/media/beets/app/kustomization.yaml
@@ -3,5 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: media
 resources:
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/media/beets/app/ocirepository.yaml
+++ b/kubernetes/apps/media/beets/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: beets
+  namespace: media
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/media/beets/ks.yaml
+++ b/kubernetes/apps/media/beets/ks.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app beets
+spec:
+  components:
+    - ../../../../components/kopiur/backup
+  targetNamespace: media
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: kopiur
+      namespace: kopiur-system
+    - name: miroir-config
+      namespace: miroir-system
+    - name: external-secrets-stores
+      namespace: security
+  path: ./kubernetes/apps/media/beets/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      APP_UID: "1000"
+      APP_GID: "1000"
+      KOPIUR_CLAIM: beets-config
+      KOPIUR_CAPACITY: 5Gi

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - ./qui/ks.yaml
   - ./sabnzbd/ks.yaml
   - ./slskd/ks.yaml
+  - ./beets/ks.yaml
   - ./unpackerr/ks.yaml
   - ./profilarr/ks.yaml
   - ./seerr/ks.yaml


### PR DESCRIPTION
## Why

Replaces the Lidarr approach (#4000, closed). Lidarr is bound to MusicBrainz through `api.lidarr.audio`, so an album MB has never heard of cannot be added at all — which was the actual complaint. beets can import as-is (`bootleg`) or match against Discogs, and it's a far better tagger. Acquisition stays manual via slskd's own UI, which searches Soulseek filenames and doesn't care what MB knows. Music Assistant keeps playback, so no Navidrome.

## What

- `beets/ks.yaml` — kopiur backup Component, `beets-config` @ 5Gi, mover uid/gid 1000
- `beets/app/helmrelease.yaml` — app-template 5.0.1, `pspitzner/beets-flask:v2.0.0-rc5` (beets 2.11.0), port 5001, `beets.nikola.wtf` via the `internal` gateway
- `beets/app/externalsecret.yaml` — Discogs personal access token from the `beets` item in the `homecluster` vault
- Inbox wired to `/media/Download/soulseek/complete` in `preview` mode — previews are generated automatically, imports stay a manual click. 8 albums are already sitting there.

## Rootless, without forking the image

Upstream's entrypoint runs as root purely to `usermod` its `beetle` user to `USER_ID`/`GROUP_ID` and then `su`s down. In the image `beetle` is **already 1000:1000** and owns `/config`, `/logs`, `/repo` and `/venv`, so that whole dance is a no-op for us. The container overrides `command` to launch the server directly under the repo's usual `runAsNonRoot: true` / 1000:1000 pod context, and no custom image is needed.

Consequences of skipping `su beetle`, both handled: `HOME` must be set explicitly (uv's cache and the web terminal's tmux need it), and `entrypoint_user_scripts.sh` has to be invoked by us.

`readOnlyRootFilesystem` is deliberately left off: the bundled redis writes its dump into `/repo/backend`.

## Discogs plugin

The image ships beets 2.11.0 but not `python3-discogs-client`, so the plugin would fail to load. Rather than forking the image, it's installed through upstream's documented extension point — a `/config/requirements.txt` that `entrypoint_user_scripts.sh` pip-installs into the venv on boot.

The token never lands in Git: the ExternalSecret renders a `secrets.yaml` which the beets config pulls in with `include:` (relative to the config dir, per beets' config reference). This is what enables entering a Discogs ID at the `enter Id` prompt for releases MusicBrainz lacks.

**Before merging:** replace the placeholder in the `discogs_token` field of the `beets` item (`homecluster` vault) with a real PAT from https://www.discogs.com/settings/developers. The placeholder means a missing token degrades to failed Discogs lookups rather than a pod that won't start.

## Library database migration

The existing library (19,415 tracks, 1,912 albums) had a stale path root from the old OpenMediaVault box — `/srv/dev-disk-by-label-storage01/Music/library`, plus 9 tracks under `/mnt/disk1/...`. Files themselves are all in place.

Paths were rewritten to `/media/Music/Music/library` with byte-level replacement in Python (not SQL `CAST`) to preserve BLOB typing and avoid a UTF-8 round-trip on the 1,633 non-ASCII paths. Verified afterwards: BLOB types intact, no stale prefixes left, **19,408/19,415 tracks and 1,785/1,785 artpaths resolve on disk**.

The rewritten copy sits on the share as `musiclibrary.beets-flask.db` (the original `musiclibrary.db` is untouched as a backup) and an init container seeds it onto the PVC on first start, after which kopiur backs it up nightly. The db deliberately lives on miroir rather than NFS — beets-flask runs 4 uvicorn workers plus redis and watchdog workers against it, and SQLite over NFS with concurrent writers is asking for corruption.

Known gap: 7 tracks of one album (`Temple of the Smoke`, untitled/year 0) point at files that no longer exist — that folder holds a single `00.mp3`. Pre-existing damage, fixable with `beet update` or a re-import.

## Caveat on paths

`paths` is reconstructed from the existing on-disk layout (`$albumartist/%if{$year,($year) }$album/$track $title`) since no old beets config survived anywhere on the share — new imports may differ cosmetically from old folders.

## Validation

`kustomize build`, `flux build ks` dry-run, and `helm template` against app-template 5.0.1 (confirms the init container, custom TCP probes, and all four nested configMap/secret subPath mounts render). yamlfmt + yamllint clean. NFS access was verified from inside the cluster: a pod at uid 1000 can read and write the library tree — the export squashes new files to `977:988`.