### PR TITLE
fix(media): make beets config dirs writable by the app

### DIFF
--- a/kubernetes/apps/media/beets/app/helmrelease.yaml
+++ b/kubernetes/apps/media/beets/app/helmrelease.yaml
@@ -23,9 +23,29 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         initContainers:
+          # kubelet creates /config/beets and /config/beets-flask as root:root to host the
+          # nested config.yaml mounts, and fsGroup only covers volume content that already
+          # exists at mount time. Both dirs need to be writable by the app: beets puts its
+          # library db and state in the first, beets-flask its sqlite db in the second.
+          # Not recursive — the mounted config files themselves are read-only.
+          01-fix-permissions:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.37.0
+            command:
+              - sh
+              - -c
+              - |
+                set -eu
+                mkdir -p /config/beets /config/beets-flask
+                chown 1000:1000 /config/beets /config/beets-flask
+            securityContext:
+              runAsUser: 0
+              runAsGroup: 0
+              runAsNonRoot: false
           # Seed the existing 19k-track library on first start; the db on the share
           # already carries paths rewritten from the old /srv/dev-disk-by-label-storage01 root.
-          seed-library:
+          02-seed-library:
             image:
               repository: docker.io/library/busybox
               tag: 1.37.0
@@ -35,7 +55,6 @@ spec:
               - |
                 set -eu
                 if [ ! -f /config/beets/musiclibrary.db ]; then
-                  mkdir -p /config/beets
                   cp /media/Music/Music/musiclibrary.beets-flask.db /config/beets/musiclibrary.db
                 fi
         containers:


### PR DESCRIPTION
Follow-up to #4001. The library-db seed failed on first boot:

```
cp: can't create '/config/beets/musiclibrary.db': Permission denied
```

## Cause

`/config/beets` and `/config/beets-flask` are created by kubelet as `root:root 0755` because they host the nested `config.yaml` subPath mounts. `fsGroup` only applies to volume content that already exists when the volume is mounted, so those freshly-created mountpoint dirs never get group ownership — leaving uid 1000 unable to write into them.

The seed was the first symptom, but beets-flask would have hit the same wall creating its own sqlite db in `/config/beets-flask`, and beets its `state.pickle` in `/config/beets`.

## Fix

A root init container chowns both dirs to 1000:1000 before the seed runs — the same approach `ai/hermes` already uses for `/run`. Deliberately **not** recursive: the config files mounted inside are read-only projections and chowning them would fail.

Init containers are ordered by key, hence the `01-`/`02-` prefixes.

## Validation

`helm template` confirms ordering and that `01-fix-permissions` runs as uid 0 while `02-seed-library` inherits the pod's 1000. `kustomize build`, yamlfmt and yamllint clean.