### PR TITLE
fix(media): beets include must be a list

### DIFF
--- a/kubernetes/apps/media/beets/app/helmrelease.yaml
+++ b/kubernetes/apps/media/beets/app/helmrelease.yaml
@@ -143,8 +143,10 @@ spec:
             directory: /media/Music/Music/library
             library: /config/beets/musiclibrary.db
 
-            # Discogs user_token, rendered from 1Password by the ExternalSecret
-            include: secrets.yaml
+            # Discogs user_token, rendered from 1Password by the ExternalSecret.
+            # Must be a list: beets calls .sequence() on it.
+            include:
+              - secrets.yaml
 
             plugins:
               - musicbrainz


### PR DESCRIPTION
Follow-up to #4001. Every uvicorn worker died on startup:

```
confuse.exceptions.ConfigTypeError: include must be a list, not str
```

beets' config reference describes `include` as "a space-separated list of extra configuration files", but `beets/__init__.py` does `for view in self["include"].sequence()` — which requires an actual YAML sequence. The scalar form fails hard, and since the config is read per worker it took down all four plus the watchdog.

```diff
-include: secrets.yaml
+include:
+  - secrets.yaml
```

## Everything else in that boot was healthy

- `entrypoint_user_scripts.sh` installed `python3-discogs-client==2.9` + `oauthlib` into the venv from `/config/requirements.txt`
- `Running as 'beetle' with UID 1000 and GID 1000` — the rootless override works
- `/config/beets-flask` was writable, so alembic ran its initial migration and created the sqlite db (#4002 doing its job)

## Validation

The rendered `beets.yaml` was parsed with PyYAML to confirm `include` is a list and the document is valid. `kustomize build`, yamlfmt, yamllint clean.