### PR TITLE
feat(volsync): reinstall volsync on miroir to refresh restic repos (rollback phase A)

### DIFF
--- a/kubernetes/apps/ai/hermes/ks.yaml
+++ b/kubernetes/apps/ai/hermes/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: ai
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/ai/memini/ks.yaml
+++ b/kubernetes/apps/ai/memini/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: ai
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/home/appdaemon/ks.yaml
+++ b/kubernetes/apps/home/appdaemon/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/home/esphome/ks.yaml
+++ b/kubernetes/apps/home/esphome/ks.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
     labels:
@@ -14,6 +15,8 @@ spec:
   dependsOn:
     - name: multus-config
       namespace: network
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/home/govee2mqtt/ks.yaml
+++ b/kubernetes/apps/home/govee2mqtt/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/home/home-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/home/home-assistant/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./pvc.yaml
+  - ./replicationsource.yaml

--- a/kubernetes/apps/home/home-assistant/app/replicationsource.yaml
+++ b/kubernetes/apps/home/home-assistant/app/replicationsource.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: home-assistant-media-r2
+spec:
+  sourcePVC: home-assistant-media
+  trigger:
+    schedule: "0 0 * * *"
+  restic:
+    cacheCapacity: 2Gi
+    cacheStorageClassName: openebs-hostpath
+    copyMethod: Snapshot
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    pruneIntervalDays: 7
+    repository: home-assistant-media-volsync-r2
+    retain:
+      daily: 7
+    storageClassName: miroir
+    volumeSnapshotClassName: miroir
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: home-assistant-media-volsync-r2
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: home-assistant-media-volsync-r2
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        RESTIC_REPOSITORY: "{{ .REPOSITORY_TEMPLATE }}/home-assistant-media"
+        RESTIC_PASSWORD: "{{ .RESTIC_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: volsync-r2-template

--- a/kubernetes/apps/home/home-assistant/ks.yaml
+++ b/kubernetes/apps/home/home-assistant/ks.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
     labels:
@@ -14,6 +15,8 @@ spec:
   dependsOn:
     - name: multus-config
       namespace: network
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/home/matter-server/ks.yaml
+++ b/kubernetes/apps/home/matter-server/ks.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
     labels:
@@ -14,6 +15,8 @@ spec:
   dependsOn:
     - name: multus-config
       namespace: network
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/home/mosquitto/app/kustomization.yaml
+++ b/kubernetes/apps/home/mosquitto/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./pvc.yaml
+  - ./replicationsource.yaml

--- a/kubernetes/apps/home/mosquitto/app/replicationsource.yaml
+++ b/kubernetes/apps/home/mosquitto/app/replicationsource.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: mosquitto-r2
+spec:
+  sourcePVC: mosquitto-data
+  trigger:
+    schedule: "0 0 * * *"
+  restic:
+    cacheCapacity: 2Gi
+    cacheStorageClassName: openebs-hostpath
+    copyMethod: Snapshot
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    pruneIntervalDays: 7
+    repository: mosquitto-volsync-r2
+    retain:
+      daily: 7
+    storageClassName: miroir
+    volumeSnapshotClassName: miroir
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mosquitto-volsync-r2
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: mosquitto-volsync-r2
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        RESTIC_REPOSITORY: "{{ .REPOSITORY_TEMPLATE }}/mosquitto"
+        RESTIC_PASSWORD: "{{ .RESTIC_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: volsync-r2-template

--- a/kubernetes/apps/home/music-assistant/ks.yaml
+++ b/kubernetes/apps/home/music-assistant/ks.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
     labels:
@@ -14,6 +15,8 @@ spec:
   dependsOn:
     - name: multus-config
       namespace: network
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/home/otbr/ks.yaml
+++ b/kubernetes/apps/home/otbr/ks.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
     labels:
@@ -14,6 +15,8 @@ spec:
   dependsOn:
     - name: multus-config
       namespace: network
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/home/petkit-local/app/replicationsource.yaml
+++ b/kubernetes/apps/home/petkit-local/app/replicationsource.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: petkit-local-media-r2
+spec:
+  sourcePVC: petkit-local-media
+  trigger:
+    schedule: "0 0 * * *"
+  restic:
+    cacheCapacity: 2Gi
+    cacheStorageClassName: openebs-hostpath
+    copyMethod: Snapshot
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    pruneIntervalDays: 7
+    repository: petkit-local-media-volsync-r2
+    retain:
+      daily: 7
+    storageClassName: miroir
+    volumeSnapshotClassName: miroir
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: petkit-local-media-volsync-r2
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: petkit-local-media-volsync-r2
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        RESTIC_REPOSITORY: "{{ .REPOSITORY_TEMPLATE }}/petkit-local-media"
+        RESTIC_PASSWORD: "{{ .RESTIC_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: volsync-r2-template

--- a/kubernetes/apps/home/petkit-local/ks.yaml
+++ b/kubernetes/apps/home/petkit-local/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/home/scrypted/ks.yaml
+++ b/kubernetes/apps/home/scrypted/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/home/wyoming-onnx-asr/ks.yaml
+++ b/kubernetes/apps/home/wyoming-onnx-asr/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/home/z2mqtt/ks.yaml
+++ b/kubernetes/apps/home/z2mqtt/ks.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: home
   commonMetadata:
     labels:
@@ -19,6 +20,8 @@ spec:
     namespace: flux-system
   wait: false
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/media/bazarr/ks.yaml
+++ b/kubernetes/apps/media/bazarr/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/media/beets/ks.yaml
+++ b/kubernetes/apps/media/beets/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/media/bookboss/ks.yaml
+++ b/kubernetes/apps/media/bookboss/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/media/jellyfin/ks.yaml
+++ b/kubernetes/apps/media/jellyfin/ks.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
@@ -19,6 +20,8 @@ spec:
     namespace: flux-system
   wait: false
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/media/plex-trakt-sync/ks.yaml
+++ b/kubernetes/apps/media/plex-trakt-sync/ks.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
@@ -19,6 +20,8 @@ spec:
     namespace: flux-system
   wait: false
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
@@ -19,6 +20,8 @@ spec:
     namespace: flux-system
   wait: false
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/media/profilarr/ks.yaml
+++ b/kubernetes/apps/media/profilarr/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/media/qbittorrent/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/media/qui/ks.yaml
+++ b/kubernetes/apps/media/qui/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/media/sabnzbd/ks.yaml
+++ b/kubernetes/apps/media/sabnzbd/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/media/seerr/ks.yaml
+++ b/kubernetes/apps/media/seerr/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/media/shelfmark/ks.yaml
+++ b/kubernetes/apps/media/shelfmark/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/media/slskd/ks.yaml
+++ b/kubernetes/apps/media/slskd/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/media/tautulli/ks.yaml
+++ b/kubernetes/apps/media/tautulli/ks.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
@@ -19,6 +20,8 @@ spec:
     namespace: flux-system
   wait: false
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/media/unpackerr/ks.yaml
+++ b/kubernetes/apps/media/unpackerr/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: media
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/misc/forgejo/ks.yaml
+++ b/kubernetes/apps/misc/forgejo/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: misc
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/misc/invoicing/ks.yaml
+++ b/kubernetes/apps/misc/invoicing/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: misc
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/misc/manyfold/ks.yaml
+++ b/kubernetes/apps/misc/manyfold/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: misc
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/misc/n8n/ks.yaml
+++ b/kubernetes/apps/misc/n8n/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: misc
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/misc/paperless/ks.yaml
+++ b/kubernetes/apps/misc/paperless/ks.yaml
@@ -7,11 +7,14 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: misc
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/o11y/gatus/app/kustomization.yaml
+++ b/kubernetes/apps/o11y/gatus/app/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
   - ./prometheusrule.yaml
+  - ./replicationsource.yaml
 configMapGenerator:
   - name: gatus-configmap
     files:

--- a/kubernetes/apps/o11y/gatus/app/replicationsource.yaml
+++ b/kubernetes/apps/o11y/gatus/app/replicationsource.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: gatus-r2
+spec:
+  sourcePVC: gatus-gatus-sidecar
+  trigger:
+    schedule: "0 0 * * *"
+  restic:
+    cacheCapacity: 2Gi
+    cacheStorageClassName: openebs-hostpath
+    copyMethod: Snapshot
+    moverSecurityContext:
+      runAsUser: 65532
+      runAsGroup: 65532
+      fsGroup: 65532
+    pruneIntervalDays: 7
+    repository: gatus-volsync-r2
+    retain:
+      daily: 7
+    storageClassName: miroir
+    volumeSnapshotClassName: miroir
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gatus-volsync-r2
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: gatus-volsync-r2
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        RESTIC_REPOSITORY: "{{ .REPOSITORY_TEMPLATE }}/gatus"
+        RESTIC_PASSWORD: "{{ .RESTIC_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: volsync-r2-template

--- a/kubernetes/apps/o11y/health-metrics/app/kustomization.yaml
+++ b/kubernetes/apps/o11y/health-metrics/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./externalsecret.yaml
   - ./vmsingle.yaml
   - ./vmagent.yaml
+  - ./replicationsource.yaml

--- a/kubernetes/apps/o11y/health-metrics/app/replicationsource.yaml
+++ b/kubernetes/apps/o11y/health-metrics/app/replicationsource.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: vmsingle-health-r2
+spec:
+  sourcePVC: vmsingle-health
+  trigger:
+    schedule: "0 0 * * *"
+  restic:
+    cacheCapacity: 2Gi
+    cacheStorageClassName: openebs-hostpath
+    copyMethod: Snapshot
+    moverSecurityContext:
+      runAsUser: 0
+      runAsGroup: 0
+      fsGroup: 0
+    pruneIntervalDays: 7
+    repository: vmsingle-health-volsync-r2
+    retain:
+      daily: 7
+    storageClassName: miroir
+    volumeSnapshotClassName: miroir
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: vmsingle-health-volsync-r2
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: vmsingle-health-volsync-r2
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        RESTIC_REPOSITORY: "{{ .REPOSITORY_TEMPLATE }}/vmsingle-health"
+        RESTIC_PASSWORD: "{{ .RESTIC_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: volsync-r2-template

--- a/kubernetes/apps/o11y/victorialogs/app/kustomization.yaml
+++ b/kubernetes/apps/o11y/victorialogs/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml
+  - ./replicationsource.yaml

--- a/kubernetes/apps/o11y/victorialogs/app/replicationsource.yaml
+++ b/kubernetes/apps/o11y/victorialogs/app/replicationsource.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: victorialogs-r2
+spec:
+  sourcePVC: server-volume-victorialogs-victoria-logs-single-server-0
+  trigger:
+    schedule: "0 0 * * *"
+  restic:
+    cacheCapacity: 2Gi
+    cacheStorageClassName: openebs-hostpath
+    copyMethod: Snapshot
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 2000
+      fsGroup: 2000
+    pruneIntervalDays: 7
+    repository: victorialogs-volsync-r2
+    retain:
+      daily: 7
+    storageClassName: miroir
+    volumeSnapshotClassName: miroir
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: victorialogs-volsync-r2
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: victorialogs-volsync-r2
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        RESTIC_REPOSITORY: "{{ .REPOSITORY_TEMPLATE }}/victorialogs"
+        RESTIC_PASSWORD: "{{ .RESTIC_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: volsync-r2-template

--- a/kubernetes/apps/o11y/victoriametrics/app/kustomization.yaml
+++ b/kubernetes/apps/o11y/victoriametrics/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./helmrelease.yaml
   - ./externalsecret.yaml
   - ./vmalertmanager.yaml
+  - ./replicationsource.yaml

--- a/kubernetes/apps/o11y/victoriametrics/app/replicationsource.yaml
+++ b/kubernetes/apps/o11y/victoriametrics/app/replicationsource.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: vmsingle-vmetrics-r2
+spec:
+  sourcePVC: vmsingle-vmetrics-victoria-metrics-k8s-stack
+  trigger:
+    schedule: "0 0 * * *"
+  restic:
+    cacheCapacity: 2Gi
+    cacheStorageClassName: openebs-hostpath
+    copyMethod: Snapshot
+    moverSecurityContext:
+      runAsUser: 0
+      runAsGroup: 0
+      fsGroup: 0
+    pruneIntervalDays: 7
+    repository: vmsingle-vmetrics-volsync-r2
+    retain:
+      daily: 7
+    storageClassName: miroir
+    volumeSnapshotClassName: miroir
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: vmsingle-vmetrics-volsync-r2
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: vmsingle-vmetrics-volsync-r2
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        RESTIC_REPOSITORY: "{{ .REPOSITORY_TEMPLATE }}/vmsingle-vmetrics"
+        RESTIC_PASSWORD: "{{ .RESTIC_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: volsync-r2-template

--- a/kubernetes/apps/security/atuin/ks.yaml
+++ b/kubernetes/apps/security/atuin/ks.yaml
@@ -6,8 +6,11 @@ metadata:
 spec:
   components:
     - ../../../../components/kopiur/backup
+    - ../../../../components/volsync
   targetNamespace: security
   dependsOn:
+    - name: volsync
+      namespace: security
     - name: kopiur
       namespace: kopiur-system
     - name: miroir-config

--- a/kubernetes/apps/security/kustomization.yaml
+++ b/kubernetes/apps/security/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
   - ./namespace.yaml
   - ./external-secrets/ks.yaml
   - ./snapshot-controller/ks.yaml
+  - ./volsync/ks.yaml
   - ./atuin/ks.yaml

--- a/kubernetes/apps/security/volsync/app/helmrelease.yaml
+++ b/kubernetes/apps/security/volsync/app/helmrelease.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: volsync
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: volsync
+  values:
+    manageCRDs: true
+    metrics:
+      disableAuth: true

--- a/kubernetes/apps/security/volsync/app/kustomization.yaml
+++ b/kubernetes/apps/security/volsync/app/kustomization.yaml
@@ -1,9 +1,6 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: home
 resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
-  - ./pvc.yaml
-  - ./replicationsource.yaml

--- a/kubernetes/apps/security/volsync/app/ocirepository.yaml
+++ b/kubernetes/apps/security/volsync/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: volsync
+  namespace: security
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.16.0
+  url: oci://ghcr.io/home-operations/charts-mirror/volsync

--- a/kubernetes/apps/security/volsync/ks.yaml
+++ b/kubernetes/apps/security/volsync/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &appname volsync
+spec:
+  targetNamespace: security
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *appname
+  interval: 30m
+  timeout: 5m
+  path: "./kubernetes/apps/security/volsync/app"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  dependsOn:
+    - name: snapshot-controller
+      namespace: security
+  wait: false

--- a/kubernetes/components/volsync/externalsecret.yaml
+++ b/kubernetes/components/volsync/externalsecret.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: "${APP}-volsync-r2"
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: "${APP}-volsync-r2"
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        RESTIC_REPOSITORY: "{{ .REPOSITORY_TEMPLATE }}/${APP}"
+        RESTIC_PASSWORD: "{{ .RESTIC_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: volsync-r2-template

--- a/kubernetes/components/volsync/kustomization.yaml
+++ b/kubernetes/components/volsync/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./externalsecret.yaml
+  - ./replicationsource.yaml

--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: ${APP}-r2
+spec:
+  sourcePVC: "${KOPIUR_CLAIM:-${APP}}"
+  trigger:
+    schedule: "0 0 * * *"
+  restic:
+    cacheAccessModes:
+      - "${VOLSYNC_CACHE_ACCESSMODES:-ReadWriteOnce}"
+    cacheCapacity: "${KOPIUR_CACHE_CAPACITY:-1Gi}"
+    cacheStorageClassName: "${KOPIUR_CACHE_STORAGECLASS:-openebs-hostpath}"
+    copyMethod: Snapshot
+    moverSecurityContext:
+      runAsUser: ${APP_UID:-1000}
+      runAsGroup: ${APP_GID:-1000}
+      fsGroup: ${APP_GID:-1000}
+    pruneIntervalDays: 7
+    repository: ${APP}-volsync-r2
+    retain:
+      daily: 7
+    storageClassName: "${VOLSYNC_STORAGECLASS:-miroir}"
+    volumeSnapshotClassName: "${VOLSYNC_SNAPSHOTCLASS:-miroir}"
+    moverAffinity:
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/created-by: volsync
+            namespaceSelector:
+              matchExpressions:
+                - key: kubernetes.io/metadata.name
+                  operator: Exists


### PR DESCRIPTION
First stage of the miroir -> rook-ceph rollback: volsync returns with
sources-only wiring (no pvc/replicationdestination — existing PVCs are
immutable and kopiur-populated) and snapshots the live miroir volumes into
the existing per-app restic R2 repos, bringing them current before they
become the restore source. ReplicationSources temporarily consume the
KOPIUR_* vars and the miroir snapshot class; both flip back in the rollback
PR. Standalone sources added for the seven volumes that predate volsync
coverage (mosquitto-data, HA media, petkit media, vmsingle-health,
vmsingle-vmetrics, victorialogs, gatus).
