### PR TITLE
fix(volsync): snapshot clones on miroir-local

### DIFF
--- a/kubernetes/apps/home/home-assistant/app/replicationsource.yaml
+++ b/kubernetes/apps/home/home-assistant/app/replicationsource.yaml
@@ -20,7 +20,7 @@ spec:
     repository: home-assistant-media-volsync-r2
     retain:
       daily: 7
-    storageClassName: miroir
+    storageClassName: miroir-local
     volumeSnapshotClassName: miroir
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json

--- a/kubernetes/apps/home/mosquitto/app/replicationsource.yaml
+++ b/kubernetes/apps/home/mosquitto/app/replicationsource.yaml
@@ -20,7 +20,7 @@ spec:
     repository: mosquitto-volsync-r2
     retain:
       daily: 7
-    storageClassName: miroir
+    storageClassName: miroir-local
     volumeSnapshotClassName: miroir
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json

--- a/kubernetes/apps/home/petkit-local/app/replicationsource.yaml
+++ b/kubernetes/apps/home/petkit-local/app/replicationsource.yaml
@@ -20,7 +20,7 @@ spec:
     repository: petkit-local-media-volsync-r2
     retain:
       daily: 7
-    storageClassName: miroir
+    storageClassName: miroir-local
     volumeSnapshotClassName: miroir
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json

--- a/kubernetes/apps/o11y/gatus/app/replicationsource.yaml
+++ b/kubernetes/apps/o11y/gatus/app/replicationsource.yaml
@@ -20,7 +20,7 @@ spec:
     repository: gatus-volsync-r2
     retain:
       daily: 7
-    storageClassName: miroir
+    storageClassName: miroir-local
     volumeSnapshotClassName: miroir
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json

--- a/kubernetes/apps/o11y/health-metrics/app/replicationsource.yaml
+++ b/kubernetes/apps/o11y/health-metrics/app/replicationsource.yaml
@@ -20,7 +20,7 @@ spec:
     repository: vmsingle-health-volsync-r2
     retain:
       daily: 7
-    storageClassName: miroir
+    storageClassName: miroir-local
     volumeSnapshotClassName: miroir
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json

--- a/kubernetes/apps/o11y/victorialogs/app/replicationsource.yaml
+++ b/kubernetes/apps/o11y/victorialogs/app/replicationsource.yaml
@@ -20,7 +20,7 @@ spec:
     repository: victorialogs-volsync-r2
     retain:
       daily: 7
-    storageClassName: miroir
+    storageClassName: miroir-local
     volumeSnapshotClassName: miroir
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json

--- a/kubernetes/apps/o11y/victoriametrics/app/replicationsource.yaml
+++ b/kubernetes/apps/o11y/victoriametrics/app/replicationsource.yaml
@@ -20,7 +20,7 @@ spec:
     repository: vmsingle-vmetrics-volsync-r2
     retain:
       daily: 7
-    storageClassName: miroir
+    storageClassName: miroir-local
     volumeSnapshotClassName: miroir
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json

--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -22,7 +22,7 @@ spec:
     repository: ${APP}-volsync-r2
     retain:
       daily: 7
-    storageClassName: "${VOLSYNC_STORAGECLASS:-miroir}"
+    storageClassName: "${VOLSYNC_STORAGECLASS:-miroir-local}"
     volumeSnapshotClassName: "${VOLSYNC_SNAPSHOTCLASS:-miroir}"
     moverAffinity:
       podAntiAffinity:


### PR DESCRIPTION
Backup staging clones are read-once temporaries; provisioning them on the
replicated class made every backup pay a full DRBD sync before the mover
could start (one mover at a time cluster-wide). Single-replica clones skip
the sync entirely.
