### PR TITLE
fix(volsync): drop the required mover anti-affinity

### DIFF
--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -24,14 +24,3 @@ spec:
       daily: 7
     storageClassName: "${VOLSYNC_STORAGECLASS:-miroir-local}"
     volumeSnapshotClassName: "${VOLSYNC_SNAPSHOTCLASS:-miroir}"
-    moverAffinity:
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          - topologyKey: kubernetes.io/hostname
-            labelSelector:
-              matchLabels:
-                app.kubernetes.io/created-by: volsync
-            namespaceSelector:
-              matchExpressions:
-                - key: kubernetes.io/metadata.name
-                  operator: Exists


### PR DESCRIPTION
The pre-cutover moverAffinity (required podAntiAffinity on
created-by=volsync per hostname, all namespaces) caps concurrent movers at
one per node cluster-wide. Fine as a steady-state ceph-era IO limiter,
but it stalls the 44-source restic refresh to a crawl and will equally
throttle the mass restore during the rollback window.
