### PR TITLE
feat(media): back up jellyfin /metadata volume

### DIFF
--- a/kubernetes/apps/media/jellyfin/app/kustomization.yaml
+++ b/kubernetes/apps/media/jellyfin/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./resourceclaimtemplate.yaml
+  - ./replicationsource.yaml

--- a/kubernetes/apps/media/jellyfin/app/replicationsource.yaml
+++ b/kubernetes/apps/media/jellyfin/app/replicationsource.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/volsync.backube/replicationsource_v1alpha1.json
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: jellyfin-metadata-r2
+spec:
+  sourcePVC: jellyfin
+  trigger:
+    schedule: "0 0 * * *"
+  restic:
+    cacheCapacity: 2Gi
+    cacheStorageClassName: openebs-hostpath
+    copyMethod: Snapshot
+    moverSecurityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+      fsGroup: 1000
+    pruneIntervalDays: 7
+    repository: jellyfin-metadata-volsync-r2
+    retain:
+      daily: 7
+    storageClassName: miroir-local
+    volumeSnapshotClassName: miroir
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: jellyfin-metadata-volsync-r2
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: jellyfin-metadata-volsync-r2
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        RESTIC_REPOSITORY: "{{ .REPOSITORY_TEMPLATE }}/jellyfin-metadata"
+        RESTIC_PASSWORD: "{{ .RESTIC_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: volsync-r2-template


### PR DESCRIPTION
The chart-created 'jellyfin' PVC holds downloaded artwork/metadata and was
lost in the forward migration (only claim outside the backup net). Give it
its own restic source so the rollback carries it and future rebuilds skip
the full metadata refresh.
