### PR TITLE
fix(rook-ceph): select OSD devices by model path filter

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -107,18 +107,11 @@ spec:
       storage:
         useAllNodes: true
         useAllDevices: false
+        # Data disks are all the same model; match by stable by-id path since
+        # /dev/nvmeXnY enumeration shifts across reboots (icarus003 is nvme0n1)
+        devicePathFilter: "^/dev/disk/by-id/nvme-RS1D0TSSD710_.*"
         config:
           osdsPerDevice: "1"
-        nodes:
-          - name: "icarus001"
-            devices:
-              - name: "/dev/nvme1n1"
-          - name: "icarus002"
-            devices:
-              - name: "/dev/nvme1n1"
-          - name: "icarus003"
-            devices:
-              - name: "/dev/nvme1n1"
     cephBlockPools:
       - name: ceph-blockpool
         spec:


### PR DESCRIPTION
\`useAllNodes: true\` makes rook ignore the per-node \`nodes:\` list, so fresh OSD provisioning ran with no desired devices (\`desiredDevices are []\` in the prepare logs). This never surfaced pre-migration because existing OSDs were re-detected by signature scan.

Select the data disks by stable by-id path instead — all three are the same model (RS1D0TSSD710), and \`/dev/nvmeXnY\` enumeration shifts across reboots (icarus003's data disk is \`nvme0n1\`, not \`nvme1n1\`).