### PR TITLE
chore(talos): drop drbd extension and miroir kernel modules

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -55,13 +55,6 @@ machine:
       - net.ifnames=1
     image: factory.talos.dev/installer/{{ ENV.SCHEMATIC }}:{{ ENV.TALOS_VERSION }}
     wipe: false
-  kernel:
-    modules:
-      - name: dm_thin_pool # Miroir lvmthin backend
-      - name: drbd # Miroir replication (from the siderolabs/drbd extension)
-        parameters:
-          - usermode_helper=disabled
-      - name: drbd_transport_tcp
   kubelet:
     defaultRuntimeSeccompProfileEnabled: true
     disableManifestsDirectory: true
@@ -70,7 +63,7 @@ machine:
         - net.ipv6.conf.*
       imageGCHighThresholdPercent: 70
       imageGCLowThresholdPercent: 55
-      # Miroir/DRBD needs movers and replicas demoted cleanly on shutdown
+      # Give workloads (ceph OSDs, movers) time to stop cleanly on reboot
       shutdownGracePeriod: 90s
       shutdownGracePeriodCriticalPods: 60s
     extraMounts:

--- a/talos/schematic.yaml.j2
+++ b/talos/schematic.yaml.j2
@@ -2,7 +2,6 @@
 customization:
   systemExtensions:
     officialExtensions:
-      - siderolabs/drbd # Miroir DRBD9 replication
       - siderolabs/i915
       - siderolabs/intel-ice-firmware
       - siderolabs/intel-ucode


### PR DESCRIPTION
miroir is rolled back — remove \`siderolabs/drbd\` from the factory schematic and the \`drbd\`/\`drbd_transport_tcp\`/\`dm_thin_pool\` kernel modules from the machine config.

New schematic: \`2e00237e630ea339ac40b2a205a8d2bdc87773a154e4257e2b0bebdac70aab5b\` (verified against the factory).

\`shutdownGracePeriod\` stays — clean pod shutdown on reboot benefits ceph OSDs just the same.

Rollout: \`just talos apply-node\` per node (updates the install image, no reboot), then \`just talos upgrade-node\` one node at a time to reinstall without the extension.