### PR TITLE
feat(volsync): alert on missed backups and absent metrics

### DIFF
--- a/kubernetes/apps/security/volsync/app/kustomization.yaml
+++ b/kubernetes/apps/security/volsync/app/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./prometheusrule.yaml
   - ./volumepopulator-crd.yaml

--- a/kubernetes/apps/security/volsync/app/prometheusrule.yaml
+++ b/kubernetes/apps/security/volsync/app/prometheusrule.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: volsync-rules
+spec:
+  groups:
+    - name: volsync.rules
+      rules:
+        # role="source" only: -bootstrap ReplicationDestinations are one-shot
+        # restores and report out_of_sync forever by design.
+        - alert: VolSyncVolumeOutOfSync
+          expr: |-
+            max by (obj_namespace, obj_name) (volsync_volume_out_of_sync{role="source"}) == 1
+          for: 30m
+          annotations:
+            summary: >-
+              VolSync backup {{ $labels.obj_namespace }}/{{ $labels.obj_name }}
+              missed its schedule and is out of sync
+          labels:
+            severity: warning
+        # If volsync or its scrape dies, the alert above goes blind silently.
+        - alert: VolSyncMetricsMissing
+          expr: |-
+            absent(volsync_volume_out_of_sync{role="source"})
+          for: 30m
+          annotations:
+            summary: >-
+              VolSync metrics are absent — backup monitoring is blind
+              (operator down or scrape broken)
+          labels:
+            severity: warning


### PR DESCRIPTION
Two alerts (severity \`warning\` → Telegram):

- **VolSyncVolumeOutOfSync** — a ReplicationSource missed its schedule (\`volsync_volume_out_of_sync{role="source"} == 1\` for 30m). Filtered to \`role="source"\` because the \`-bootstrap\` ReplicationDestinations are one-shot restores and report out-of-sync forever by design.
- **VolSyncMetricsMissing** — the metric is absent entirely (operator down / scrape broken), i.e. the first alert is silently blind.

Verified live: \`volsync_volume_out_of_sync\` has 91 series in vmetrics under job \`volsync-metrics\`, currently all 0.