### PR TITLE
feat(rook-ceph): enable full RBD image features on ceph-block

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -129,7 +129,7 @@ spec:
             - discard
           parameters:
             imageFormat: "2"
-            imageFeatures: layering
+            imageFeatures: layering,exclusive-lock,object-map,fast-diff
             csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
             csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
             csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner


### PR DESCRIPTION
Adds \`exclusive-lock,object-map,fast-diff\` to the \`ceph-block\` storage class \`imageFeatures\` (kernel requirement is ≥5.3; Talos 1.13 is fine).

volsync snapshots + clones every volume nightly — with \`object-map\`/\`fast-diff\`, snapshot diffs and space accounting are metadata lookups instead of full-object scans.

Applies to **new** images only. Existing 50 volumes (created 2026-08-05 with layering-only) get the features enabled live with a one-time \`rbd feature enable\` sweep after merge.