### PR TITLE
chore(scrypted): drop icarus003 node pin and USB passthrough

### DIFF
--- a/kubernetes/apps/home/scrypted/app/helmrelease.yaml
+++ b/kubernetes/apps/home/scrypted/app/helmrelease.yaml
@@ -11,8 +11,6 @@ spec:
     name: scrypted
   values:
     defaultPodOptions:
-      nodeSelector:
-        kubernetes.io/hostname: icarus003
       resourceClaims:
         - name: gpu
           resourceClaimTemplateName: scrypted
@@ -90,12 +88,6 @@ spec:
                 subPath: cache
               - path: /.npm
                 subPath: npm-cache
-      usb:
-        type: hostPath
-        hostPath: /dev/bus/usb
-        hostPathType: Directory
-        globalMounts:
-          - path: /dev/bus/usb
 
     route:
       app:


### PR DESCRIPTION
scrypted no longer depends on a USB device — remove the \`kubernetes.io/hostname: icarus003\` nodeSelector and the \`/dev/bus/usb\` hostPath mount. GPU access is unaffected (DRA resource claim schedules on any node with the iGPU).