### PR TITLE
feat(gatus): alert Telegram when the monitoring stack is down

### DIFF
--- a/kubernetes/apps/o11y/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/o11y/gatus/app/helmrelease.yaml
@@ -16,6 +16,12 @@ spec:
       delayStartSeconds: "5"
       env:
         TZ: Europe/Belgrade
+      extraEnv:
+        - name: GATUS_TELEGRAM_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: vmalert-telegram-token
+              key: token
     sidecar:
       kinds:
         httproute:

--- a/kubernetes/apps/o11y/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/o11y/gatus/app/resources/config.yaml
@@ -4,7 +4,54 @@ connectivity:
     target: 1.1.1.1:53
     interval: 1m
 
+# Gatus alerts Telegram directly — independent of the vmalert->alertmanager
+# chain, so it still fires when the monitoring stack itself is down.
+alerting:
+  telegram:
+    token: "${GATUS_TELEGRAM_TOKEN}"
+    id: "104243855"
+    default-alert:
+      enabled: true
+      failure-threshold: 3
+      success-threshold: 2
+      send-on-resolved: true
+
 endpoints:
+  - name: vmsingle-vmetrics
+    group: monitoring
+    url: http://vmsingle-vmetrics-victoria-metrics-k8s-stack.o11y.svc.cluster.local:8428/health
+    interval: 1m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: telegram
+
+  - name: vmsingle-health
+    group: monitoring
+    url: http://vmsingle-health.o11y.svc.cluster.local:8429/health
+    interval: 1m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: telegram
+
+  - name: vmalert
+    group: monitoring
+    url: http://vmalert-vmetrics-victoria-metrics-k8s-stack.o11y.svc.cluster.local:8080/health
+    interval: 1m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: telegram
+
+  - name: alertmanager
+    group: monitoring
+    url: http://vmalertmanager-vmetrics-victoria-metrics-k8s-stack.o11y.svc.cluster.local:9093/-/healthy
+    interval: 1m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: telegram
   - name: Cloudflare
     group: connectivity
     url: icmp://1.1.1.1


### PR DESCRIPTION
This morning both vmsingles were down for ~40 minutes and nothing alerted — vmalert evaluates rules by querying vmsingle, so the monitoring stack can't alert on its own death.

Gatus now probes \`vmsingle-vmetrics\`, \`vmsingle-health\`, \`vmalert\`, and \`alertmanager\` health endpoints every minute and alerts Telegram **through its own native alerting** (bot token reused from \`vmalert-telegram-token\` via \`extraEnv\`), independent of the vmalert→alertmanager chain. 3 failures to fire, 2 successes to resolve.

Remaining gap (whole-cluster death takes gatus with it) needs an external dead-man's switch — separate discussion.