### PR TITLE
feat(o11y): expose VM stack components via internal gateway

### DIFF
--- a/kubernetes/apps/o11y/health-metrics/app/httproute.yaml
+++ b/kubernetes/apps/o11y/health-metrics/app/httproute.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vmhealth
+spec:
+  hostnames:
+    - vmhealth.nikola.wtf
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: vmsingle-health
+          namespace: o11y
+          port: 8429

--- a/kubernetes/apps/o11y/health-metrics/app/kustomization.yaml
+++ b/kubernetes/apps/o11y/health-metrics/app/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - ./externalsecret.yaml
   - ./vmsingle.yaml
   - ./vmagent.yaml
+  - ./httproute.yaml
   - ./replicationsource.yaml

--- a/kubernetes/apps/o11y/victoriametrics/app/httproute.yaml
+++ b/kubernetes/apps/o11y/victoriametrics/app/httproute.yaml
@@ -1,0 +1,73 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vmsingle
+spec:
+  hostnames:
+    - vmsingle.nikola.wtf
+    - vm.nikola.wtf
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: vmsingle-vmetrics-victoria-metrics-k8s-stack
+          namespace: o11y
+          port: 8428
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vmalert
+spec:
+  hostnames:
+    - vmalert.nikola.wtf
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: vmalert-vmetrics-victoria-metrics-k8s-stack
+          namespace: o11y
+          port: 8080
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: alertmanager
+spec:
+  hostnames:
+    - alertmanager.nikola.wtf
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: vmalertmanager-vmetrics-victoria-metrics-k8s-stack
+          namespace: o11y
+          port: 9093
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vmagent
+spec:
+  hostnames:
+    - vmagent.nikola.wtf
+  parentRefs:
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: vmagent-vmetrics-victoria-metrics-k8s-stack
+          namespace: o11y
+          port: 8429

--- a/kubernetes/apps/o11y/victoriametrics/app/kustomization.yaml
+++ b/kubernetes/apps/o11y/victoriametrics/app/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - ./helmrelease.yaml
   - ./externalsecret.yaml
   - ./vmalertmanager.yaml
+  - ./httproute.yaml
   - ./replicationsource.yaml


### PR DESCRIPTION
Adds internal-gateway HTTPRoutes for the rest of the monitoring stack (grafana/gatus/vlogs already had them):

| Host | Backend |
|---|---|
| `vm.nikola.wtf` / `vmsingle.nikola.wtf` | vmsingle-vmetrics (vmui) |
| `vmalert.nikola.wtf` | vmalert UI |
| `alertmanager.nikola.wtf` | alertmanager UI |
| `vmagent.nikola.wtf` | vmagent (targets/relabel debug) |
| `vmhealth.nikola.wtf` | vmsingle-health (vmui) |

Internal gateway only — nothing exposed externally.