### PR TITLE
fix(o11y): repair or retire permanently-blind alert rules

### DIFF
--- a/kubernetes/apps/o11y/exporters/smartctl-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/o11y/exporters/smartctl-exporter/app/prometheusrule.yaml
@@ -56,12 +56,3 @@ spec:
           for: 15m
           labels:
             severity: critical
-        - alert: SmartDeviceInterfaceSlow
-          annotations:
-            summary: Device {{ $labels.device }} on instance {{ $labels.instance }}
-              interface is slower then it should be.
-          expr: |
-            smartctl_device_interface_speed{speed_type="current"} != on(device, instance, namespace, pod) smartctl_device_interface_speed{speed_type="max"}
-          for: 15m
-          labels:
-            severity: critical

--- a/kubernetes/apps/o11y/victoriametrics/app/alertmanager-prometheusrule.yaml
+++ b/kubernetes/apps/o11y/victoriametrics/app/alertmanager-prometheusrule.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+# Replaces the vendored kube-prometheus alertmanager group (disabled in the HR),
+# whose rules hardcode job="alertmanager-main"/namespace="monitoring" and the
+# clustering rules that never apply to a single-replica alertmanager.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: alertmanager-rules
+spec:
+  groups:
+    - name: alertmanager.rules
+      rules:
+        - alert: AlertmanagerFailedReload
+          expr: |-
+            max_over_time(alertmanager_config_last_reload_successful{job="vmalertmanager-vmetrics-victoria-metrics-k8s-stack"}[5m]) == 0
+          for: 10m
+          annotations:
+            summary: >-
+              Alertmanager failed to reload its configuration
+          labels:
+            severity: critical
+        - alert: AlertmanagerFailedToSendAlerts
+          expr: |-
+            rate(alertmanager_notifications_failed_total{job="vmalertmanager-vmetrics-victoria-metrics-k8s-stack"}[5m])
+            /
+            rate(alertmanager_notifications_total{job="vmalertmanager-vmetrics-victoria-metrics-k8s-stack"}[5m])
+            > 0.01
+          for: 5m
+          annotations:
+            summary: >-
+              Alertmanager is failing to send {{ $labels.integration }} notifications
+          labels:
+            severity: warning

--- a/kubernetes/apps/o11y/victoriametrics/app/helmrelease.yaml
+++ b/kubernetes/apps/o11y/victoriametrics/app/helmrelease.yaml
@@ -84,6 +84,24 @@ spec:
     grafana:
       enabled: false
 
+    kube-state-metrics:
+      # Expose KSM's own health metrics (kube_state_metrics_list_total etc.) so
+      # the KubeStateMetrics* alerts can actually see them — if KSM breaks, every
+      # kube_*-based alert goes blind with it.
+      selfMonitor:
+        enabled: true
+      vmScrape:
+        spec:
+          endpoints:
+            # Overriding the list replaces it: keep the chart's default endpoint.
+            - port: http
+              honorLabels: true
+              metricRelabelConfigs:
+                - action: labeldrop
+                  regex: (uid|container_id|image_id)
+            - port: metrics
+              honorLabels: true
+
     victoria-metrics-operator:
       enabled: true
       operator:
@@ -134,12 +152,37 @@ spec:
         KubeClientCertificateExpiration:
           spec:
             for: 1h
+        # Talos has no systemd and no mdraid — these can never fire.
+        NodeSystemdServiceFailed:
+          create: false
+        NodeSystemdServiceCrashlooping:
+          create: false
+        NodeRAIDDegraded:
+          create: false
+        NodeRAIDDiskFailure:
+          create: false
+        # Talos etcd doesn't expose grpc_server_handling_seconds histograms.
+        etcdGRPCRequestsSlow:
+          create: false
+        # kubelet serverTLSBootstrap is off — no cert renewal metrics exist.
+        KubeletServerCertificateRenewalErrors:
+          create: false
+        # Stream aggregation is not used; vm_streamaggr_* metrics never exist.
+        StreamAggrFlushTimeout:
+          create: false
+        StreamAggrDedupFlushTimeout:
+          create: false
 
       # kube-scheduler.rules are histogram-quantile recordings that yield 0 samples
       # whenever the cluster is idle (no pod scheduling), repeatedly tripping
       # RecordingRulesNoData. They only feed the kube-scheduler Grafana dashboard.
       groups:
         kubeScheduler:
+          enabled: false
+        # Vendored kube-prometheus rules hardcode job="alertmanager-main",
+        # namespace="monitoring" — can never match our vmalertmanager in o11y.
+        # Replaced by alertmanager-prometheusrule.yaml with correct selectors.
+        alertmanager:
           enabled: false
 
     alertmanager:

--- a/kubernetes/apps/o11y/victoriametrics/app/kustomization.yaml
+++ b/kubernetes/apps/o11y/victoriametrics/app/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
   - ./helmrelease.yaml
   - ./externalsecret.yaml
   - ./vmalertmanager.yaml
+  - ./alertmanager-prometheusrule.yaml
   - ./httproute.yaml
   - ./replicationsource.yaml


### PR DESCRIPTION
Audited every vmalert rule showing \`nomatch\` (zero series fetched) — 109 total, 77 are legitimately conditional (selectors like \`ready!="True"\` that only match in bad states). The other 32 could **never** fire:

- **alertmanager group**: vendored kube-prometheus rules hardcode \`job="alertmanager-main", namespace="monitoring"\` — impossible selectors for our vmalertmanager in \`o11y\`. Disabled the vendored group, added corrected \`AlertmanagerFailedReload\` + \`AlertmanagerFailedToSendAlerts\` (the clustering rules don't apply to a single replica).
- **KubeStateMetrics\* alerts were blind**: KSM's telemetry port was never scraped. Enabled \`selfMonitor\` + added the \`metrics\` endpoint to the scrape.
- **Disabled rules for things Talos doesn't have**: systemd services, mdraid, etcd gRPC histograms, kubelet server-cert renewal, vmagent stream aggregation.
- **Dropped \`SmartDeviceInterfaceSlow\`**: these NVMe drives don't report \`smartctl_device_interface_speed\` at all.

Not touched: rook's vendored \`nvmeof\`/\`rbdmirror\` groups (chart offers no granular disable, harmless) and the \`tuppr.*\` rules — those are an upstream chart bug (rules reference \`tuppr_upgrade_progressing\`/\`tuppr_upgrades_completed_total\`, which the operator doesn't export).