### PR TITLE
revert(rook-ceph): back to layering-only RBD image features

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -129,7 +129,10 @@ spec:
             - discard
           parameters:
             imageFormat: "2"
-            imageFeatures: layering,exclusive-lock,object-map,fast-diff
+            # layering ONLY. exclusive-lock+object-map+fast-diff caused ongoing
+            # data corruption around snapshot lock transitions with krbd
+            # (2026-08-05..07 incident) — do not re-enable.
+            imageFeatures: layering
             csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
             csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
             csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner


### PR DESCRIPTION
The exclusive-lock/object-map/fast-diff combo is causing **ongoing** corruption, not just the one-time live-enable incident: plex's backup clone passed fsck on Aug 6 ~10:00, and its Aug 7 00:00 clone is corrupt — new damage between two nightly snapshots, pointing at krbd lock transitions during snapshot creation. Last night's casualties: plex, scrypted, victorialogs, petkit-local-media.

Follow-up (live cluster, after merge): recreate the SC (params immutable), strip the features from all existing images, offline-fsck the four newly damaged parents, re-run their backups.