### PR TITLE
Add Kyverno policy auditing

### DIFF
--- a/kubernetes/apps/o11y/grafana-operator/instance/dashboards/kustomization.yaml
+++ b/kubernetes/apps/o11y/grafana-operator/instance/dashboards/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ./ceph.yaml
   - ./apps.yaml
   - ./kubernetes.yaml
+  - ./kyverno.yaml
   - ./monitoring.yaml
   - ./network.yaml
   - ./sleep.yaml

--- a/kubernetes/apps/o11y/grafana-operator/instance/dashboards/kyverno.yaml
+++ b/kubernetes/apps/o11y/grafana-operator/instance/dashboards/kyverno.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: kyverno
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - inputName: DS_PROMETHEUS_KYVERNO
+      datasourceName: VictoriaMetrics
+  url: https://raw.githubusercontent.com/kyverno/kyverno/v1.18.2/charts/kyverno/charts/grafana/dashboard/kyverno-dashboard.json

--- a/kubernetes/apps/security/kustomization.yaml
+++ b/kubernetes/apps/security/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - ./external-secrets/ks.yaml
   - ./snapshot-controller/ks.yaml
   - ./volsync/ks.yaml
+  - ./kyverno/ks.yaml
   - ./atuin/ks.yaml

--- a/kubernetes/apps/security/kyverno/app/helmrelease.yaml
+++ b/kubernetes/apps/security/kyverno/app/helmrelease.yaml
@@ -1,0 +1,50 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kyverno
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: kyverno
+  values:
+    crds:
+      install: true
+
+    admissionController:
+      replicas: 3
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+      serviceMonitor:
+        enabled: true
+        interval: 1m
+
+    backgroundController:
+      replicas: 2
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+      serviceMonitor:
+        enabled: true
+        interval: 1m
+
+    cleanupController:
+      replicas: 2
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+      serviceMonitor:
+        enabled: true
+        interval: 1m
+
+    reportsController:
+      replicas: 2
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+      serviceMonitor:
+        enabled: true
+        interval: 1m

--- a/kubernetes/apps/security/kyverno/app/kustomization.yaml
+++ b/kubernetes/apps/security/kyverno/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/security/kyverno/app/ocirepository.yaml
+++ b/kubernetes/apps/security/kyverno/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kyverno
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 3.8.2
+  url: oci://ghcr.io/kyverno/charts/kyverno

--- a/kubernetes/apps/security/kyverno/ks.yaml
+++ b/kubernetes/apps/security/kyverno/ks.yaml
@@ -17,4 +17,27 @@ spec:
     kind: GitRepository
     name: home-kubernetes
     namespace: flux-system
-  wait: false
+  wait: true
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kyverno-policies
+spec:
+  targetNamespace: security
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: kyverno
+  dependsOn:
+    - name: kyverno
+      namespace: security
+  interval: 30m
+  timeout: 5m
+  path: ./kubernetes/apps/security/kyverno/policies
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: true

--- a/kubernetes/apps/security/kyverno/ks.yaml
+++ b/kubernetes/apps/security/kyverno/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &appname kyverno
+spec:
+  targetNamespace: security
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *appname
+  interval: 30m
+  timeout: 10m
+  path: ./kubernetes/apps/security/kyverno/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/security/kyverno/policies/kustomization.yaml
+++ b/kubernetes/apps/security/kyverno/policies/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./policies.yaml

--- a/kubernetes/apps/security/kyverno/policies/policies.yaml
+++ b/kubernetes/apps/security/kyverno/policies/policies.yaml
@@ -9,7 +9,6 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
 spec:
-  validationFailureAction: Audit
   background: true
   emitWarning: true
   rules:
@@ -20,6 +19,7 @@ spec:
               kinds:
                 - Pod
       validate:
+        failureAction: Audit
         message: CPU and memory requests are required for all containers.
         pattern:
           spec:
@@ -49,7 +49,6 @@ metadata:
     policies.kyverno.io/severity: high
     policies.kyverno.io/subject: Pod
 spec:
-  validationFailureAction: Audit
   background: true
   emitWarning: true
   rules:
@@ -60,6 +59,7 @@ spec:
               kinds:
                 - Pod
       validate:
+        failureAction: Audit
         message: Privileged containers are not allowed.
         pattern:
           spec:
@@ -79,6 +79,7 @@ spec:
               kinds:
                 - Pod
       validate:
+        failureAction: Audit
         message: Privilege escalation must be explicitly disabled.
         pattern:
           spec:
@@ -102,7 +103,6 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
 spec:
-  validationFailureAction: Audit
   background: true
   emitWarning: true
   rules:
@@ -113,6 +113,7 @@ spec:
               kinds:
                 - Pod
       validate:
+        failureAction: Audit
         message: Pod or container security contexts must explicitly require a non-root user.
         anyPattern:
           - spec:
@@ -148,7 +149,6 @@ metadata:
     policies.kyverno.io/severity: medium
     policies.kyverno.io/subject: Pod
 spec:
-  validationFailureAction: Audit
   background: true
   emitWarning: true
   rules:
@@ -159,6 +159,7 @@ spec:
               kinds:
                 - Pod
       validate:
+        failureAction: Audit
         message: Container images must be pinned to immutable digests.
         pattern:
           spec:

--- a/kubernetes/apps/security/kyverno/policies/policies.yaml
+++ b/kubernetes/apps/security/kyverno/policies/policies.yaml
@@ -1,0 +1,170 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-resource-requests
+  annotations:
+    policies.kyverno.io/title: Require Resource Requests
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+spec:
+  validationFailureAction: Audit
+  background: true
+  emitWarning: true
+  rules:
+    - name: require-resource-requests
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: CPU and memory requests are required for all containers.
+        pattern:
+          spec:
+            containers:
+              - resources:
+                  requests:
+                    cpu: "?*"
+                    memory: "?*"
+            "=(initContainers)":
+              - resources:
+                  requests:
+                    cpu: "?*"
+                    memory: "?*"
+            "=(ephemeralContainers)":
+              - resources:
+                  requests:
+                    cpu: "?*"
+                    memory: "?*"
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-privileged-containers
+  annotations:
+    policies.kyverno.io/title: Disallow Privileged Containers
+    policies.kyverno.io/category: Pod Security Standards (Baseline)
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+spec:
+  validationFailureAction: Audit
+  background: true
+  emitWarning: true
+  rules:
+    - name: disallow-privileged-containers
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: Privileged containers are not allowed.
+        pattern:
+          spec:
+            containers:
+              - "=(securityContext)":
+                  "=(privileged)": false
+            "=(initContainers)":
+              - "=(securityContext)":
+                  "=(privileged)": false
+            "=(ephemeralContainers)":
+              - "=(securityContext)":
+                  "=(privileged)": false
+    - name: disallow-privilege-escalation
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: Privilege escalation must be explicitly disabled.
+        pattern:
+          spec:
+            containers:
+              - securityContext:
+                  allowPrivilegeEscalation: false
+            "=(initContainers)":
+              - securityContext:
+                  allowPrivilegeEscalation: false
+            "=(ephemeralContainers)":
+              - securityContext:
+                  allowPrivilegeEscalation: false
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-run-as-non-root
+  annotations:
+    policies.kyverno.io/title: Require runAsNonRoot
+    policies.kyverno.io/category: Pod Security Standards (Restricted)
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+spec:
+  validationFailureAction: Audit
+  background: true
+  emitWarning: true
+  rules:
+    - name: require-run-as-non-root
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: Pod or container security contexts must explicitly require a non-root user.
+        anyPattern:
+          - spec:
+              securityContext:
+                runAsNonRoot: true
+              containers:
+                - "=(securityContext)":
+                    "=(runAsNonRoot)": true
+              "=(initContainers)":
+                - "=(securityContext)":
+                    "=(runAsNonRoot)": true
+              "=(ephemeralContainers)":
+                - "=(securityContext)":
+                    "=(runAsNonRoot)": true
+          - spec:
+              containers:
+                - securityContext:
+                    runAsNonRoot: true
+              "=(initContainers)":
+                - securityContext:
+                    runAsNonRoot: true
+              "=(ephemeralContainers)":
+                - securityContext:
+                    runAsNonRoot: true
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-image-digests
+  annotations:
+    policies.kyverno.io/title: Require Image Digests
+    policies.kyverno.io/category: Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Pod
+spec:
+  validationFailureAction: Audit
+  background: true
+  emitWarning: true
+  rules:
+    - name: require-image-digests
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      validate:
+        message: Container images must be pinned to immutable digests.
+        pattern:
+          spec:
+            containers:
+              - image: "*@sha256:*"
+            "=(initContainers)":
+              - image: "*@sha256:*"
+            "=(ephemeralContainers)":
+              - image: "*@sha256:*"


### PR DESCRIPTION
## Summary
- deploy Kyverno 3.8.2 through the security namespace Flux hierarchy with highly available controllers and ServiceMonitors
- audit resource requests, privileged containers and privilege escalation, non-root execution, and immutable image digests
- apply policies only after the Kyverno deployment and CRDs become ready
- add the official Kyverno v1.18.2 Grafana dashboard backed by VictoriaMetrics

## Test plan
- [x] render the recursive Flux application tree
- [x] validate rendered resources with kubeconform
- [x] render and validate the Kyverno Helm chart
- [x] exercise all audit policies with compliant and noncompliant Pods using Kyverno CLI v1.18.2
- [x] render the GrafanaDashboard and verify its datasource mapping
- [x] lint changed YAML manifests