### PR TITLE
Harden workloads against Kyverno audit findings

### DIFF
--- a/kubernetes/apps/ai/grafana-mcp/app/mcpserver.yaml
+++ b/kubernetes/apps/ai/grafana-mcp/app/mcpserver.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   groupRef:
     name: mcp-tools
-  image: docker.io/grafana/mcp-grafana:1.1.0
+  image: docker.io/grafana/mcp-grafana:1.1.0@sha256:f21a19cebbfa7c3a76ef1746171e5ffc3601064e432f593e7c6cb526e5216e5f
   transport: streamable-http
   mcpPort: 8000
   env:

--- a/kubernetes/apps/ai/ha-mcp/app/mcpserver.yaml
+++ b/kubernetes/apps/ai/ha-mcp/app/mcpserver.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   groupRef:
     name: mcp-tools
-  image: ghcr.io/homeassistant-ai/ha-mcp:8.2.0
+  image: ghcr.io/homeassistant-ai/ha-mcp:8.2.0@sha256:dbcfc0ee8ad02d2190ebde69e5cc6167175c79608bbf1d55cff9034e256face1
   transport: streamable-http
   env:
     - name: HOMEASSISTANT_URL
@@ -15,6 +15,10 @@ spec:
   secrets:
     - name: ha-mcp-secret
       key: HOMEASSISTANT_TOKEN
+  resources:
+    requests:
+      cpu: 10m
+      memory: 192Mi
   podTemplateSpec:
     spec:
       containers:

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -21,22 +21,33 @@ spec:
         initContainers:
           # readOnlyRootFilesystem needs /run to be writable and owned by the app uid
           fix-run:
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
             image:
               repository: docker.io/library/busybox
-              tag: latest
+              tag: latest@sha256:dc2d74b28e4cf8984fa52af1f39bc7c3d9c73760b41a74d629f5d11b1ab28616
             command:
               - "sh"
               - "-c"
               - "chown 10000:10000 /run && chmod 755 /run"
             securityContext:
+              allowPrivilegeEscalation: false
               runAsUser: 0
               runAsGroup: 0
               runAsNonRoot: false
           # Merge the pinned config over the copy on the PVC (pinned keys win, user edits preserved)
           init:
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+            securityContext:
+              allowPrivilegeEscalation: false
             image:
               repository: docker.io/mikefarah/yq
-              tag: "4"
+              tag: "4@sha256:11a1f0b604b13dbbdc662260d8db6f644b22d8553122a25c1b5b2e8713ca6977"
             command:
               - sh
               - -c
@@ -52,6 +63,12 @@ spec:
           # Install gh, Go and Homebrew onto the PVC so the agent can build/install
           # tools at runtime. Idempotent — only downloads on first boot, reused after.
           install-tools:
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
             image:
               repository: nousresearch/hermes-agent
               tag: &imageTag v2026.8.3@sha256:16788311e2fa3035456bdc1bafb8ec2b1777db64ebf020af9bb7eb73c3712c9e
@@ -84,9 +101,13 @@ spec:
           # Install the memini memory-provider plugin into HERMES_HOME/plugins (PVC).
           # Delete /opt/data/plugins/memini to force a re-pull on the next rollout.
           install-memini-plugin:
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
             image:
               repository: docker.io/alpine/git
-              tag: v2.54.0
+              tag: v2.54.0@sha256:3b44767883ac77bddae0160cc27b6b039345e23fa3504f4159efaa32264ab57f
             command:
               - sh
               - -c

--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -67,6 +67,13 @@ spec:
           schedule: "0 5 * * *"
         containers:
           fsck:
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+            image:
+              repository: docker.io/curlimages/curl
+              tag: 8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
             env:
               MEMINI_API_KEY:
                 valueFrom:

--- a/kubernetes/apps/ai/toolhive/config/embeddingserver.yaml
+++ b/kubernetes/apps/ai/toolhive/config/embeddingserver.yaml
@@ -8,5 +8,9 @@ spec:
   env:
     - name: HOSTNAME
       value: "::"
-  image: ghcr.io/huggingface/text-embeddings-inference:cpu-latest
+  image: ghcr.io/huggingface/text-embeddings-inference:cpu-latest@sha256:cb570aabbfa016b86684f576b5bd72d1ee96cc0b7a00b0ad221b298762b32157
   model: sentence-transformers/all-MiniLM-L6-v2
+  resources:
+    requests:
+      cpu: 25m
+      memory: 512Mi

--- a/kubernetes/apps/home/appdaemon/app/helmrelease.yaml
+++ b/kubernetes/apps/home/appdaemon/app/helmrelease.yaml
@@ -28,9 +28,15 @@ spec:
 
         containers:
           app:
+            resources:
+              requests:
+                cpu: 15m
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
             image:
               repository: docker.io/acockburn/appdaemon
-              tag: 4.5.13
+              tag: 4.5.13@sha256:cabcb3a4e739db2572ecb8dc3cee685300ab27274efda83a6d8ce4d3988dc647
             env:
               HA_URL: "http://home-assistant-app:8123"
               DASH_URL: "http://0.0.0.0:5050"

--- a/kubernetes/apps/home/asterisk/app/helmrelease.yaml
+++ b/kubernetes/apps/home/asterisk/app/helmrelease.yaml
@@ -34,9 +34,11 @@ spec:
               }]
         containers:
           app:
+            securityContext:
+              allowPrivilegeEscalation: false
             image:
               repository: ghcr.io/tech7fox/asterisk-hass-addon
-              tag: latest
+              tag: latest@sha256:3a2ef8f7a8efbe91926a65daf8ba8c4b6bfd9c0658c9874b45aee114fc936c83
             env:
               HA_URL: "https://hass.nikola.wtf"
             envFrom:

--- a/kubernetes/apps/home/go2rtc/app/helmrelease.yaml
+++ b/kubernetes/apps/home/go2rtc/app/helmrelease.yaml
@@ -29,6 +29,12 @@ spec:
           # mount is read-only (add -> "read-only file system" -> HTTP 400), so
           # seed a writable copy that go2rtc can rewrite at runtime.
           init-config:
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+            securityContext:
+              allowPrivilegeEscalation: false
             image:
               repository: docker.io/alexxit/go2rtc
               tag: 1.9.14@sha256:675c318b23c06fd862a61d262240c9a63436b4050d177ffc68a32710d9e05bae

--- a/kubernetes/apps/home/govee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home/govee2mqtt/app/helmrelease.yaml
@@ -26,9 +26,13 @@ spec:
               }]
         containers:
           app:
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
             image:
               repository: ghcr.io/wez/govee2mqtt
-              tag: 2025.01.04-abbd0b48
+              tag: 2025.01.04-abbd0b48@sha256:954a77361dd846ab468a4934d579c784416f2cd7c177ce183249e8a62ae2ad99
               pullPolicy: IfNotPresent
             env:
               GOVEE_MQTT_HOST: "mosquitto.home.svc"

--- a/kubernetes/apps/home/hms-cpap/app/helmrelease.yaml
+++ b/kubernetes/apps/home/hms-cpap/app/helmrelease.yaml
@@ -22,6 +22,10 @@ spec:
       hms-cpap:
         containers:
           app:
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
             image:
               repository: ghcr.io/hms-homelab/hms-cpap
               tag: latest@sha256:e4d67b0d9354ccb0d598d78e1fe892b9617301c651b5ad3318214e1614798e31

--- a/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/home-assistant/app/helmrelease.yaml
@@ -59,6 +59,8 @@ spec:
 
         containers:
           app:
+            securityContext:
+              allowPrivilegeEscalation: false
             image:
               repository: quay.io/nklmilojevic/home-assistant
               tag: 2026.8.1@sha256:57770480ac97e839182a77948cfa793bb1bdd284f0e6cf7e43ef03718ea2e179
@@ -84,7 +86,7 @@ spec:
           openssh:
             image:
               repository: quay.io/nklmilojevic/openssh
-              tag: 3.24.1
+              tag: 3.24.1@sha256:aff17c0c3f44667a777cab37fb72ee8a553bdc900ea6200794393f95cde2a62e
             env:
               TZ: "Europe/Belgrade"
               PUBLIC_KEY: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICrYywYsK/kocVOa48LjaOR2X10g7lwsB1PtkyBJX800 id_ed25519"

--- a/kubernetes/apps/home/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/home/mosquitto/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: eclipse-mosquitto
-              tag: 2.0.22
+              tag: 2.0.22@sha256:212f89e1eaeb2c322d6441b64396e3346026674db8fa9c27beac293405c32b3c
             env:
               TZ: "Europe/Belgrade"
             probes:

--- a/kubernetes/apps/home/otbr/app/helmrelease.yaml
+++ b/kubernetes/apps/home/otbr/app/helmrelease.yaml
@@ -44,7 +44,7 @@ spec:
           app:
             image:
               repository: ghcr.io/ownbee/hass-otbr-docker
-              tag: v0.3.0
+              tag: v0.3.0@sha256:5ca7008462e94d4c937aca8c1c9a60e709d6d300625363c161b946683032d5b1
             env:
               DEVICE: /tmp/ttyOTBR
               NETWORK_DEVICE: "10.50.0.205:6638"

--- a/kubernetes/apps/home/scrypted/app/helmrelease.yaml
+++ b/kubernetes/apps/home/scrypted/app/helmrelease.yaml
@@ -43,6 +43,8 @@ spec:
 
         containers:
           app:
+            securityContext:
+              allowPrivilegeEscalation: false
             image:
               repository: ghcr.io/bjw-s-labs/scrypted
               tag: 0.141.0@sha256:c9e82faec2e27debeba03fd8d4bdb2aa53cdaf0f3f8aa77c04312a047db4c2ea

--- a/kubernetes/apps/home/wyoming-kokoro/app/helmrelease.yaml
+++ b/kubernetes/apps/home/wyoming-kokoro/app/helmrelease.yaml
@@ -14,9 +14,11 @@ spec:
       wyoming-kokoro:
         containers:
           app:
+            securityContext:
+              allowPrivilegeEscalation: false
             image:
               repository: ghcr.io/relvacode/kokoro-wyoming
-              tag: v2025.1.1
+              tag: v2025.1.1@sha256:ff15cfb276045bd61662162d9f70c2596c1cb5acd345c3f62835b2aea397ba69
             env:
               TZ: Europe/Belgrade
             resources:

--- a/kubernetes/apps/home/wyoming-onnx-asr/app/helmrelease.yaml
+++ b/kubernetes/apps/home/wyoming-onnx-asr/app/helmrelease.yaml
@@ -14,9 +14,11 @@ spec:
       wyoming-onnx-asr:
         containers:
           app:
+            securityContext:
+              allowPrivilegeEscalation: false
             image:
               repository: ghcr.io/tboby/wyoming-onnx-asr
-              tag: v0.5.0
+              tag: v0.5.0@sha256:9b2ccdd52c7aa83e36a2d674de749c4c01bd6bb1e23ea45dd85befb9fc013340
             args:
               # --model-en instead of --model-multilingual: upstream _LANGUAGE_CODES
               # omits "en", so HA grays the engine out for English pipelines

--- a/kubernetes/apps/home/z2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home/z2mqtt/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: koenkk/zigbee2mqtt
-              tag: 2.13.0
+              tag: 2.13.0@sha256:4fb4db4d49a217bed6d0204f454ce809febc565bbe051b85c556ee2bcef73d8c
               pullPolicy: IfNotPresent
             env:
               ZIGBEE2MQTT_DATA: "/data"

--- a/kubernetes/apps/media/beets/app/helmrelease.yaml
+++ b/kubernetes/apps/media/beets/app/helmrelease.yaml
@@ -29,9 +29,13 @@ spec:
           # library db and state in the first, beets-flask its sqlite db in the second.
           # Not recursive — the mounted config files themselves are read-only.
           01-fix-permissions:
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
             image:
               repository: docker.io/library/busybox
-              tag: 1.38.0
+              tag: 1.38.0@sha256:dc2d74b28e4cf8984fa52af1f39bc7c3d9c73760b41a74d629f5d11b1ab28616
             command:
               - sh
               - -c
@@ -40,15 +44,22 @@ spec:
                 mkdir -p /config/beets /config/beets-flask
                 chown 1000:1000 /config/beets /config/beets-flask
             securityContext:
+              allowPrivilegeEscalation: false
               runAsUser: 0
               runAsGroup: 0
               runAsNonRoot: false
           # Seed the existing 19k-track library on first start; the db on the share
           # already carries paths rewritten from the old /srv/dev-disk-by-label-storage01 root.
           02-seed-library:
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+            securityContext:
+              allowPrivilegeEscalation: false
             image:
               repository: docker.io/library/busybox
-              tag: 1.38.0
+              tag: 1.38.0@sha256:dc2d74b28e4cf8984fa52af1f39bc7c3d9c73760b41a74d629f5d11b1ab28616
             command:
               - sh
               - -c

--- a/kubernetes/apps/media/bookboss/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bookboss/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/szinn/bookboss
-              tag: v0.8.33
+              tag: v0.8.33@sha256:81b890792644ce7c93afd4d800d1b58bb8d15284271bab50cca201d652a3d669
             env:
               TZ: "Europe/Belgrade"
               BOOKBOSS__DATABASE__DATABASE_URL: sqlite:///data/bookboss.db?mode=rwc

--- a/kubernetes/apps/media/cobalt-web/app/helmrelease.yaml
+++ b/kubernetes/apps/media/cobalt-web/app/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
           app:
             image:
               repository: quay.io/nklmilojevic/cobalt-web
-              tag: 11.7.1
+              tag: 11.7.1@sha256:9497cb8be12436cc8ad434453f491d8e8931c395f3d0f4f59a40675a1534286a
             env:
               TZ: "Europe/Belgrade"
             probes:

--- a/kubernetes/apps/media/cobalt/app/helmrelease.yaml
+++ b/kubernetes/apps/media/cobalt/app/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
           app:
             image:
               repository: ghcr.io/imputnet/cobalt
-              tag: 11.7.1
+              tag: 11.7.1@sha256:63186dd68afd57ce3bb1f62cc4c139f5fa95b9c3e87a3cf5c6e4c7a570523f62
             env:
               TZ: "Europe/Belgrade"
               API_URL: "https://cobalt-api.nikola.wtf/"

--- a/kubernetes/apps/media/droppedneedle/app/helmrelease.yaml
+++ b/kubernetes/apps/media/droppedneedle/app/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
           app:
             image:
               repository: ghcr.io/habirabbu/droppedneedle
-              tag: v2.3.0
+              tag: v2.3.0@sha256:2a64f2cad5e531efb4895df08aec08123e5aa7215658a1a57109bd66588941b6
 
             env:
               TZ: "Europe/Belgrade"

--- a/kubernetes/apps/media/plex-trakt-sync/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex-trakt-sync/app/helmrelease.yaml
@@ -29,9 +29,11 @@ spec:
             fsGroupChangePolicy: OnRootMismatch
         containers:
           app:
+            securityContext:
+              allowPrivilegeEscalation: false
             image:
               repository: ghcr.io/taxel/plextraktsync
-              tag: 0.35.17
+              tag: 0.35.17@sha256:a028a5b7a1258ec23a5b046679d8056390c62505a38a995ed29510ff69b5fb2f
             args:
               - watch
             env:

--- a/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sabnzbd/app/helmrelease.yaml
@@ -35,7 +35,7 @@ spec:
           app:
             image:
               repository: quay.io/nklmilojevic/sabnzbd
-              tag: 5.1.0
+              tag: 5.1.0@sha256:da41f3a8a17e3d6a4b5690da6e668e6f5b7c079d3416642031592032415d3fb6
 
             env:
               TZ: "Europe/Belgrade"

--- a/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
+++ b/kubernetes/apps/media/shelfmark/app/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
           app:
             image:
               repository: ghcr.io/calibrain/shelfmark
-              tag: v1.3.6
+              tag: v1.3.6@sha256:22688cce89c0d5eca8be6f371cff6b0326fdee5540cd4992faa451d133e76989
             command:
               - gunicorn
             args:

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: quay.io/nklmilojevic/sonarr
-              tag: 4.0.19.3001
+              tag: 4.0.19.3001@sha256:ee831a9c895824e2bc6349f4c02a165018cf234062bc8cb951d4744ce186d547
 
             env:
               TZ: "Europe/Belgrade"

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: quay.io/nklmilojevic/tautulli
-              tag: 2.17.2
+              tag: 2.17.2@sha256:928344153ad29859eaaa9aac219c043c97f8bef53a36f9f7621776bf23c89400
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/apps/media/unpackerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/unpackerr/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/unpackerr/unpackerr
-              tag: 0.15.2
+              tag: 0.15.2@sha256:89e13608521ece21dd300c39229fd595a55fbf4b8152771af5670a7455b5c747
             env:
               UN_INTERVAL: 1m
               UN_WEBSERVER_METRICS: true

--- a/kubernetes/apps/misc/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/misc/forgejo/app/helmrelease.yaml
@@ -16,6 +16,7 @@ spec:
       registry: code.forgejo.org
       repository: forgejo/forgejo
       tag: 16.0.2
+      digest: sha256:23ccc146e6dc2cd1f5c5435909baae64db873201717f1726490dae649283e6cd
       rootless: true
 
     podSecurityContext:

--- a/kubernetes/apps/misc/manyfold/app/helmrelease.yaml
+++ b/kubernetes/apps/misc/manyfold/app/helmrelease.yaml
@@ -24,9 +24,13 @@ spec:
             fsGroupChangePolicy: OnRootMismatch
         initContainers:
           chown-tmpdirs:
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
             image:
               repository: docker.io/library/alpine
-              tag: "3.24"
+              tag: "3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b"
             command:
               - /bin/sh
               - -c
@@ -45,7 +49,7 @@ spec:
           app:
             image:
               repository: ghcr.io/bjw-s-labs/manyfold
-              tag: 0.147.0
+              tag: 0.147.0@sha256:88fb41930cb725c910b7a43a792dfb5fe09e44024860782daeddb6ff66729d53
             env:
               TZ: "Europe/Belgrade"
               DATABASE_URL: sqlite3:/data/database/manyfold.sqlite3

--- a/kubernetes/apps/misc/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/misc/n8n/app/helmrelease.yaml
@@ -24,9 +24,11 @@ spec:
 
         containers:
           app:
+            securityContext:
+              allowPrivilegeEscalation: false
             image:
               repository: ghcr.io/n8n-io/n8n
-              tag: 2.35.2
+              tag: 2.35.2@sha256:76ceaf6a44e0448788f690ef8719fedefe5d260771165f288fdeb5d05bc3b3a6
             env:
               DB_SQLITE_VACUUM_ON_STARTUP: true
               EXECUTIONS_DATA_PRUNE: true

--- a/kubernetes/apps/misc/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/misc/paperless/app/helmrelease.yaml
@@ -18,9 +18,11 @@ spec:
 
         containers:
           app:
+            securityContext:
+              allowPrivilegeEscalation: false
             image:
               repository: ghcr.io/paperless-ngx/paperless-ngx
-              tag: 3.0.5
+              tag: 3.0.5@sha256:65a4cabf0169ea7fbd90ab7bb28ba3f8b5909613635acda1a03ad606f34b456b
             env:
               # Configure application
               PAPERLESS_SECRET_KEY:

--- a/kubernetes/apps/misc/stirling-pdf/app/helmrelease.yaml
+++ b/kubernetes/apps/misc/stirling-pdf/app/helmrelease.yaml
@@ -15,6 +15,8 @@ spec:
       stirling-pdf:
         containers:
           app:
+            securityContext:
+              allowPrivilegeEscalation: false
             image:
               repository: ghcr.io/stirling-tools/s-pdf
               tag: 2.14.3@sha256:3b3670fce70b396ec56ba380a3cc7858e0abf83fe13f31c88f7737847763a396

--- a/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflared/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
           app:
             image:
               repository: docker.io/cloudflare/cloudflared
-              tag: 2026.8.0
+              tag: 2026.8.0@sha256:2535e54b16adf1d50630f99d0886471926c5ef3f6b328100ec6589f731c48969
             env:
               NO_AUTOUPDATE: true
               TUNNEL_CRED_FILE: /etc/cloudflared/creds/credentials.json

--- a/kubernetes/apps/network/isponsorblocktv/app/helmrelease.yaml
+++ b/kubernetes/apps/network/isponsorblocktv/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dmunozv04/isponsorblocktv
-              tag: v2.10.0
+              tag: v2.10.0@sha256:f2e4c7e57f6fcb490156759bcc79561ac594675354923a71f1f034a3fe39d7de
             env:
               TZ: "Europe/Belgrade"
 

--- a/kubernetes/apps/network/openspeedtest/app/helmrelease.yaml
+++ b/kubernetes/apps/network/openspeedtest/app/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
           app:
             image:
               repository: openspeedtest/latest
-              tag: v2.0.6
+              tag: v2.0.6@sha256:a6a7e3b3e9e93cfe7b9b2eb49c60b2a93644149a0a600845d4df57148b193ff6
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/apps/network/privado-socks/app/helmrelease.yaml
+++ b/kubernetes/apps/network/privado-socks/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: docker.io/gogost/gost
-              tag: 3.2.6
+              tag: 3.2.6@sha256:1ae76fcd556aec335ff602a1828c1140c27d6243c7f02a89f41e177baa265faf
             args:
               - -C
               - /etc/gost/gost.yaml

--- a/kubernetes/apps/network/smtp-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/network/smtp-relay/app/helmrelease.yaml
@@ -33,7 +33,7 @@ spec:
           app:
             image:
               repository: ghcr.io/foxcpp/maddy
-              tag: 0.9.5
+              tag: 0.9.5@sha256:de42151adff6388edb5e4ee88f60334fa1ab85e309485193ecb1c2db20203315
             env:
               DEBUG: "false"
               SMTP_PORT: "587"

--- a/kubernetes/apps/network/tailscale/app/helmrelease.yaml
+++ b/kubernetes/apps/network/tailscale/app/helmrelease.yaml
@@ -33,7 +33,7 @@ spec:
           app:
             image:
               repository: ghcr.io/tailscale/tailscale
-              tag: v1.102.2
+              tag: v1.102.2@sha256:321ce041508c19079b57a28b6666c8d81ab0b08accc0a2585b3ab663d557ac24
             command:
               - /bin/sh
               - /scripts/entrypoint.sh

--- a/kubernetes/apps/o11y/grafana-image-renderer/app/helmrelease.yaml
+++ b/kubernetes/apps/o11y/grafana-image-renderer/app/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
           app:
             image:
               repository: docker.io/grafana/grafana-image-renderer
-              tag: v5.12.1
+              tag: v5.12.1@sha256:e925ba95a07372527cd79827381f83f3fe7895511ee46508e35fd9400b56a369
             env:
               TZ: "Europe/Belgrade"
               GOMEMLIMIT: 768MiB

--- a/kubernetes/apps/o11y/nut-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/o11y/nut-exporter/app/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
           app:
             image:
               repository: ghcr.io/druggeri/nut_exporter
-              tag: "3.3.0"
+              tag: "3.3.0@sha256:276460d141c732772f8b1fcd785a7de272473e6d39fd85c32b163efc2999cb9a"
             env:
               TZ: "Europe/Belgrade"
               NUT_EXPORTER_SERVER: "network-ups-tools.o11y.svc"

--- a/kubernetes/apps/o11y/vector/app/agent/helmrelease.yaml
+++ b/kubernetes/apps/o11y/vector/app/agent/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
           app:
             image:
               repository: docker.io/timberio/vector
-              tag: 0.57.0-alpine
+              tag: 0.57.0-alpine@sha256:19e3526faf4d4b1ed0c28a0d68d4cc3a1e13e437099986a5b7a768707907497c
             env:
               PROCFS_ROOT: /host/proc
               SYSFS_ROOT: /host/sys

--- a/kubernetes/apps/o11y/vector/app/aggregator/helmrelease.yaml
+++ b/kubernetes/apps/o11y/vector/app/aggregator/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
           app:
             image:
               repository: docker.io/timberio/vector
-              tag: 0.57.0-alpine
+              tag: 0.57.0-alpine@sha256:19e3526faf4d4b1ed0c28a0d68d4cc3a1e13e437099986a5b7a768707907497c
             args:
               - "--config"
               - "/etc/vector/vector.yaml"


### PR DESCRIPTION
## Summary

- pin 43 directly managed container images to immutable digests while preserving readable tags
- disable privilege escalation on 16 compatible app and init containers
- add CPU and memory requests to 14 under-accounted app and init containers

## Verification

- rendered the complete recursive Flux tree: 704 resources, 0 invalid, 0 errors
- rendered all 40 changed Helm releases: 159 resources, 0 invalid, 0 errors
- linted all changed YAML with `yamllint`
- validated ToolHive custom resources with Kubernetes server-side dry-run
- exercised the Kyverno audit policies against rendered workloads; remaining findings are reviewed deferred, intentional hardware/root requirements, or chart-generated resources

The unrelated local `flake.lock` modification is intentionally excluded.