### PR TITLE
Restore Scrypted s6 startup privileges

### DIFF
--- a/kubernetes/apps/home/scrypted/app/helmrelease.yaml
+++ b/kubernetes/apps/home/scrypted/app/helmrelease.yaml
@@ -43,8 +43,6 @@ spec:
 
         containers:
           app:
-            securityContext:
-              allowPrivilegeEscalation: false
             image:
               repository: ghcr.io/bjw-s-labs/scrypted
               tag: 0.141.0@sha256:c9e82faec2e27debeba03fd8d4bdb2aa53cdaf0f3f8aa77c04312a047db4c2ea


### PR DESCRIPTION
## Summary

- remove `allowPrivilegeEscalation: false` from the Scrypted app container
- restore the setuid transition required by the image's s6 overlay startup

## Rollout evidence

The Batch A rollout entered `CrashLoopBackOff` with:

```
s6-overlay-suexec: warning: unable to gain root privileges
s6-mkdir: warning: unable to mkdir /run/s6: Permission denied
s6-overlay-suexec: fatal: child failed with exit code 111
```

## Verification

- rendered the Scrypted app-template Helm release
- kubeconform: 4 resources, 0 invalid, 0 errors

The image digest pin remains in place.